### PR TITLE
Use the optimized version of signature group parsing in the snapshot library

### DIFF
--- a/src/facets/SnapshotsFacet.sol
+++ b/src/facets/SnapshotsFacet.sol
@@ -43,21 +43,6 @@ contract SnapshotsFacet is AccessControlled, Constants, SnapshotsEvents, Stoppab
         return ChainStatusLibrary.epoch();
     }
 
-    function extractUint32(bytes calldata src, uint idx) external pure returns (uint32 val) {
-        return SnapshotsLibrary.extractUint32(src, idx);
-    }
-
-    function extractUint256(bytes calldata src, uint offset) external pure returns (uint256 val) {
-        return SnapshotsLibrary.extractUint256(src, offset);
-    }
-
-    function reverse(bytes memory orig) external pure returns (bytes memory reversed) {
-        return SnapshotsLibrary.reverse(orig);
-    }
-
-    function parseSignatureGroup(bytes memory _signatureGroup) external pure returns (uint256[4] memory publicKey, uint256[2] memory signature) {
-        return SnapshotsLibrary.parseSignatureGroup(_signatureGroup);
-    }
 
     function getChainIdFromSnapshot(uint256 snapshotNumber) external view returns (uint32) {
         return SnapshotsLibrary.getChainIdFromSnapshot(snapshotNumber);

--- a/src/facets/SnapshotsFacet.t.sol
+++ b/src/facets/SnapshotsFacet.t.sol
@@ -17,38 +17,18 @@ contract SnapshotsFacetTest is Constants, DSTest, Setup {
         assertEq(snapshots.epoch(), 13);
     }
 
-    function testExtractUint32() public {
-        bytes memory b = hex"01020400";
 
-        uint expected = 262657;
-        uint32 actual = snapshots.extractUint32(b, 0);
-
-        assertEq(actual, expected);
-    }
-
-    function testExtractUint256() public {
-        bytes memory b = 
-            hex"10d7b2c2f196fceb52d546ea33816bdcf2fa5dcc79bcbcf0ce34ca1128b0d6d8"
-            hex"2d8652a0c5193001a55c0c43b5e0450297d3824a039d924b08d46520b354251f"
-            hex"105a55d55c282005a5813480b48ee1efd61046d06b6084bafcf3c10dac57584b"
-            hex"0f0bb886f1f1e04bcfa575020e3f47cceb3c11cd5cba496e5aedddc3a04d5b5c";
-
-        uint256 expected = 0xd8d6b02811ca34cef0bcbc79cc5dfaf2dc6b8133ea46d552ebfc96f1c2b2d710;
-        uint256 actual = snapshots.extractUint256(b, 0);
-
-        assertEq(actual, expected);
-    }
 
     function testFailSnapshot() public {
-        bytes memory bclaims = 
+        bytes memory bclaims =
             hex"00000000010004002b0000000a0000000d000000020100001900000002010000"
             hex"250000000201000031000000020100007565a2d7195f43727e1141f00228fd60"
             hex"da3ca7ada3fc0a5a34ea537e0cb82e8dc5d2460186f7233c927e7db2dcc703c0"
             hex"e500b653ca82273b7bfad8045d85a47000000000000000000000000000000000"
             hex"00000000000000000000000000000000ede353f57b9e2599f9165fde4ec80b60"
             hex"0e9c20418aa3f4d3d6aabee6981abff6";
-            
-        bytes memory signatureGroup = 
+
+        bytes memory signatureGroup =
             hex"2ee01ec6218252b7e263cb1d86e6082f7e05e0c86b17607c5490cd2a73ac14f6"
             hex"2cc0679acd5fb16c0c983806d13127354423e908fec273db1fc62c38fcee59d5"
             hex"2570a1763029316ee5cb6e44a74039f15935f110898ad495ffe837335ced059d"
@@ -60,18 +40,18 @@ contract SnapshotsFacetTest is Constants, DSTest, Setup {
 
         snapshots.snapshot(signatureGroup, bclaims);
     }
-    
+
     function testSnapshot() public {
-            
-        bytes memory bclaims = 
+
+        bytes memory bclaims =
             hex"00000000010004002a000000050000000d000000020100001900000002010000"
             hex"250000000201000031000000020100007565a2d7195f43727e1141f00228fd60"
             hex"da3ca7ada3fc0a5a34ea537e0cb82e8dc5d2460186f7233c927e7db2dcc703c0"
             hex"e500b653ca82273b7bfad8045d85a47000000000000000000000000000000000"
             hex"00000000000000000000000000000000ede353f57b9e2599f9165fde4ec80b60"
             hex"0e9c20418aa3f4d3d6aabee6981abff6";
-            
-        bytes memory signatureGroup = 
+
+        bytes memory signatureGroup =
             hex"2ee01ec6218252b7e263cb1d86e6082f7e05e0c86b17607c5490cd2a73ac14f6"
             hex"2cc0679acd5fb16c0c983806d13127354423e908fec273db1fc62c38fcee59d5"
             hex"2570a1763029316ee5cb6e44a74039f15935f110898ad495ffe837335ced059d"
@@ -101,17 +81,17 @@ contract SnapshotsFacetTest is Constants, DSTest, Setup {
         uint32 chainId = snapshots.getChainIdFromSnapshot(epoch);
         assertEq(uint256(chainId), 42);
     }
-    
+
     function testSnapshot2() public {
-        bytes memory bclaims = 
+        bytes memory bclaims =
             hex"00000000010004002a000000050000000d000000020100001900000002010000"
             hex"250000000201000031000000020100007565a2d7195f43727e1141f00228fd60"
             hex"da3ca7ada3fc0a5a34ea537e0cb82e8dc5d2460186f7233c927e7db2dcc703c0"
             hex"e500b653ca82273b7bfad8045d85a47000000000000000000000000000000000"
             hex"00000000000000000000000000000000ede353f57b9e2599f9165fde4ec80b60"
             hex"0e9c20418aa3f4d3d6aabee6981abff6";
-            
-        bytes memory signatureGroup = 
+
+        bytes memory signatureGroup =
             hex"2ee01ec6218252b7e263cb1d86e6082f7e05e0c86b17607c5490cd2a73ac14f6"
             hex"2cc0679acd5fb16c0c983806d13127354423e908fec273db1fc62c38fcee59d5"
             hex"2570a1763029316ee5cb6e44a74039f15935f110898ad495ffe837335ced059d"
@@ -180,15 +160,15 @@ contract SnapshotsFacetTest is Constants, DSTest, Setup {
     }
 
     function goodSnapshot() internal {
-        bytes memory bclaims = 
+        bytes memory bclaims =
             hex"00000000010004002a000000050000000d000000020100001900000002010000"
             hex"250000000201000031000000020100007565a2d7195f43727e1141f00228fd60"
             hex"da3ca7ada3fc0a5a34ea537e0cb82e8dc5d2460186f7233c927e7db2dcc703c0"
             hex"e500b653ca82273b7bfad8045d85a47000000000000000000000000000000000"
             hex"00000000000000000000000000000000ede353f57b9e2599f9165fde4ec80b60"
             hex"0e9c20418aa3f4d3d6aabee6981abff6";
-            
-        bytes memory signatureGroup = 
+
+        bytes memory signatureGroup =
             hex"2ee01ec6218252b7e263cb1d86e6082f7e05e0c86b17607c5490cd2a73ac14f6"
             hex"2cc0679acd5fb16c0c983806d13127354423e908fec273db1fc62c38fcee59d5"
             hex"2570a1763029316ee5cb6e44a74039f15935f110898ad495ffe837335ced059d"


### PR DESCRIPTION
## Scope

What is changing with this PR?

This PR is changing the method that the snapshot library is using to parse the blob of data with the signature group to a more optimized version. 

## Why?

Why are we doing this?

The new optimized method should cut the gas cost by 65k 
