### PR TITLE
Create Deposit Methods on MadBytes

### DIFF
--- a/src/GovernanceProposeEvictValidators.sol
+++ b/src/GovernanceProposeEvictValidators.sol
@@ -49,7 +49,6 @@ contract GovernanceProposeEvictValidators is GovernanceProposal {
     }
 
     function removeSetOfValidators() internal {
-        function removeSetOfValidators() internal {
         // todo: unstake the validators prior removal?
 
         // Change the variables _validatorX and _madIDX to match the addresses and
@@ -63,7 +62,6 @@ contract GovernanceProposeEvictValidators is GovernanceProposal {
         address _validator3 = address(0x2);
         uint256[2] memory _madID3 = [uint256(8), uint256(8)];
         ParticipantsLibrary.removeValidator(_validator3, _madID3);
-    }
     }
 
     function removeAllValidators() internal {

--- a/src/MadByte.sol
+++ b/src/MadByte.sol
@@ -13,7 +13,7 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
 
     /// @notice Event emitted when a deposit is received
     event DepositReceived(uint256 indexed depositID, address indexed depositor, uint256 amount);
-    event DepositReceivedBN(uint256 indexed depositID, bytes32 to0, bytes32 to1, bytes32 to2, bytes32 to3, uint256 amount);
+    event DepositReceivedBN(uint256 indexed depositID, uint256 to0, uint256 to1, uint256 to2, uint256 to3, uint256 amount);
 
     uint256 constant marketSpread = 4;
     uint256 constant madUnitOne = 1000;
@@ -22,16 +22,18 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
     uint256 _poolBalance = 0;
     uint256 _minerSplit = 500;
 
+    // struct to define a BNAddress
     struct BNAddress {
-        bytes32 to0;
-        bytes32 to1;
-        bytes32 to2;
-        bytes32 to3;
+        uint256 to0;
+        uint256 to1;
+        uint256 to2;
+        uint256 to3;
     }
 
     // Monotonically increasing variable to track the MadBytes deposits.
     uint256 _depositID = 0;
-    // Total amount of MadBytes that were deposited in this contract.
+    // Total amount of MadBytes that were deposited in the MadNet chain. The
+    // MadBytes deposited in the Madnet are burned by this contract.
     uint256 _totalDeposited = 0;
 
     // Tracks the amount of each deposit. Key is deposit id, value is amount
@@ -55,93 +57,190 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         _foundation = IMagicEthTransfer(foundation_);
     }
 
+    /// @dev sets the miner staking contract, must only be called by _admin.
     function setMinerStaking(address minerStaking_) public onlyAdmin {
         _minerStaking = IMagicEthTransfer(minerStaking_);
     }
 
+    /// @dev sets the staking contract, must only be called by _admin.
     function setMadStaking(address madStaking_) public onlyAdmin {
         _madStaking = IMagicEthTransfer(madStaking_);
     }
 
+    /// @dev sets the foundation contract, must only be called by _admin.
     function setFoundation(address foundation_) public onlyAdmin {
         _foundation = IMagicEthTransfer(foundation_);
     }
 
+    /// @dev sets the percentage that will be divided between the miners and the
+    /// stakers, must only be called by and _admin
     function setMinerSplit(uint256 split_) public onlyAdmin {
         require(split_ < madUnitOne, "MadByte: The split value should be less than the madUnitOne!");
         _minerSplit = split_;
     }
 
+    /// Converts an amount of Madbytes in ether given a point in the bonding
+    /// curve (poolbalance and totalsupply at given time).
+    /// @param poolBalance_ The pool balance (in ether) at a given moment
+    /// where we want to compute the amount of ether.
+    /// @param totalSupply_ The total supply of MadBytes at a given moment
+    /// where we want to compute the amount of ether.
+    /// @param numMB_ Amount of Madbytes that we want to convert in ether
     function MBtoEth(uint256 poolBalance_, uint256 totalSupply_, uint256 numMB_) public pure returns(uint256 numEth) {
       return _MBtoEth(poolBalance_, totalSupply_, numMB_);
     }
 
+    /// Converts an amount of ether in Madbytes given a point in the bonding
+    /// curve (poolbalance at given time).
+    /// @param poolBalance_ The pool balance (in ether) at a given moment
+    /// where we want to compute the amount of madbytes.
+    /// @param numEth_ Amount of ether that we want to convert in MadBytes
     function EthtoMB(uint256 poolBalance_, uint256 numEth_) public pure returns(uint256) {
       return _EthtoMB(poolBalance_, numEth_);
     }
 
+    /// Gets the pool balance in ether
     function getPoolBalance() public view returns(uint256) {
         return _poolBalance;
     }
 
+    /// Gets the total amount of MadBytes that were deposited in the Madnet
+    /// blockchain. Since MadBytes are burned when deposited, this value will be
+    /// different from the total supply of MadBytes.
     function getTotalMadBytesDeposited() public view returns(uint256) {
         return _totalDeposited;
     }
 
+    /// Gets the deposited amount given a depositID.
+    /// @param depositID The Id of the deposit
     function getDeposit(uint256 depositID) public view returns(uint256) {
         require(depositID <= _depositID, "MadByte: Invalid deposit ID!");
         return _deposits[depositID];
     }
 
+    /// Gets the owner of a given depositID. It returns 2 types of
+    /// address. The former is in case the owner has a normal address 20 bytes
+    /// long address. The later is in case the owner has a BN address (4x
+    /// uint256).
+    /// @param depositID The Id of the deposit
     function getDepositOwner(uint256 depositID) public view returns(address, BNAddress memory) {
         require(depositID <= _depositID, "MadByte: Invalid deposit ID!");
         return (_depositors[depositID], _depositorsBN[depositID]);
     }
 
+    /// Distributes the yields of the MadBytes sale to all stakeholders
+    /// (miners, stakers, foundation, etc).
     function distribute() public returns(uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) {
         return _distribute();
     }
 
+    /// Deposits a MadByte amount into the MadNet blockchain. The Madbyte amount
+    /// is deducted from the sender and it is burned by this contract. The
+    /// created deposit Id is owned by the sender.
+    /// @param amount_ The amount of Madbytes to be deposited
+    /// Return The deposit ID of the deposit created
     function deposit(uint256 amount_) public returns (uint256) {
         return _deposit(msg.sender, amount_);
     }
 
+    /// Deposits a MadByte amount into the MadNet blockchain. The Madbyte amount
+    /// is deducted from the sender and it is burned by this contract. The
+    /// created deposit Id is owned by the to_ address.
+    /// @param to_ The address of the account that will own the deposit
+    /// @param amount_ The amount of Madbytes to be deposited
+    /// Return The deposit ID of the deposit created
     function depositTo(address to_, uint256 amount_) public returns (uint256) {
         return _deposit(to_, amount_);
     }
 
-    function depositToBN(bytes32 to0_, bytes32 to1_, bytes32 to2_, bytes32 to3_, uint256 amount_) public returns (uint256) {
+    /// Deposits a MadByte amount into the MadNet blockchain to a BN address.
+    /// The Madbyte amount is deducted from the sender and it is burned by this
+    /// contract. The created deposit Id is owned by the toX_ address.
+    /// @param to0_ Part of the BN address
+    /// @param to1_ Part of the BN address
+    /// @param to2_ Part of the BN address
+    /// @param to3_ Part of the BN address
+    /// @param amount_ The amount of Madbytes to be deposited
+    /// Return The deposit ID of the deposit created
+    function depositToBN(uint256 to0_, uint256 to1_, uint256 to2_, uint256 to3_, uint256 amount_) public returns (uint256) {
         return _depositBN(to0_, to1_, to2_, to3_, amount_);
     }
 
+    /// Allows deposits to be minted in a virtual manner and sent to the Madnet
+    /// chain by simply emitting a Deposit event without actually minting or
+    /// burning any tokens, must only be called by _admin.
+    /// @param to_ The address of the account that will own the deposit
+    /// @param amount_ The amount of Madbytes to be deposited
+    /// Return The deposit ID of the deposit created
     function virtualMintDeposit(address to_, uint256 amount_) public onlyAdmin returns (uint256) {
         return _virtualDeposit(to_, amount_);
     }
 
-    function mintDeposit(address to_, uint256 amountMin_) public payable returns (uint256) {
-        return _mintDeposit(to_, amountMin_, msg.value);
+    /// Allows deposits to be minted in a virtual manner and sent to the Madnet
+    /// chain by simply emitting a Deposit event without actually minting or
+    /// burning any tokens. This function receives ether in the transaction and
+    /// converts them into a deposit of MadBytes in the Madnet chain.
+    /// This function has the same effect as calling mint (creating the
+    /// tokens) + deposit (burning the tokens) functions but spending less gas.
+    /// @param to_ The address of the account that will own the deposit
+    /// @param minMB_ The amount of Madbytes to be deposited
+    /// Return The deposit ID of the deposit created
+    function mintDeposit(address to_, uint256 minMB_) public payable returns (uint256) {
+        return _mintDeposit(to_, minMB_, msg.value);
     }
 
+    /// Mints MadBytes. This function receives ether in the transaction and
+    /// converts them into MadBytes using a bonding price curve.
+    /// @param minMB_ Minimum amount of MadBytes that you wish to mint given an
+    /// amount of ether. If its not possible to mint the desired amount with the
+    /// current price in the bonding curve, the transaction is reverted. If the
+    /// minMB_ is met, the whole amount of ether sent will be converted in MadBytes.
+    /// Return The number of MadBytes minted
     function mint(uint256 minMB_) public payable returns(uint256 nuMB) {
         nuMB = _mint(msg.sender, msg.value, minMB_);
         return nuMB;
     }
 
+    /// Mints MadBytes. This function receives ether in the transaction and
+    /// converts them into MadBytes using a bonding price curve.
+    /// @param to_ The account to where the tokens will be minted
+    /// @param minMB_ Minimum amount of MadBytes that you wish to mint given an
+    /// amount of ether. If its not possible to mint the desired amount with the
+    /// current price in the bonding curve, the transaction is reverted. If the
+    /// minMB_ is met, the whole amount of ether sent will be converted in MadBytes.
+    /// Return The number of MadBytes minted
     function mintTo(address to_, uint256 minMB_) public payable returns(uint256 nuMB) {
         nuMB = _mint(to_, msg.value, minMB_);
         return nuMB;
     }
 
+    /// Burn MadBytes. This function sends ether corresponding to the amount of
+    /// Madbytes being burned using a bonding price curve.
+    /// @param amount_ The amount of MadBytes being burned
+    /// @param minEth_ Minimum amount ether that you expect to receive given the
+    /// amount of MadBytes being burned. If the amount of MadBytes being burned
+    /// worth less than this amount the transaction is reverted.
+    /// Return The number of ether being received
     function burn(uint256 amount_, uint256 minEth_) public returns(uint256 numEth) {
         numEth = _burn(msg.sender, msg.sender, amount_, minEth_);
         return numEth;
     }
 
+    /// Burn MadBytes and send the ether received to other account. This
+    /// function sends ether corresponding to the amount of Madbytes being
+    /// burned using a bonding price curve.
+    /// @param to_ The account to where the ether from the burning will send
+    /// @param amount_ The amount of MadBytes being burned
+    /// @param minEth_ Minimum amount ether that you expect to receive given the
+    /// amount of MadBytes being burned. If the amount of MadBytes being burned
+    /// worth less than this amount the transaction is reverted.
+    /// Return The number of ether being received
     function burnTo(address to_, uint256 amount_, uint256 minEth_) public returns(uint256 numEth) {
         numEth = _burn(msg.sender, to_,  amount_, minEth_);
         return numEth;
     }
 
+    /// Distributes the yields from the MadBytes minting to all stake holders.
     function _distribute() internal withLock returns(uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) {
         // make a local copy to save gas
         uint256 poolBalance = _poolBalance;
@@ -170,6 +269,7 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return (foundationAmount, minerAmount, stakingAmount);
     }
 
+    // Check if addr_ is EOA (Externally Owned Account) or a contract.
     function _isContract(address addr_) internal returns (bool) {
         uint256 size;
         assembly{
@@ -178,10 +278,22 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return size > 0;
     }
 
+    // Burn the tokens during deposits without sending ether back to user as the
+    // normal burn function. The ether will be distributed in the distribute
+    // method.
+    function _destroyTokens(uint256 nuMB_) internal returns (bool) {
+        require(nuMB_ != 0, "MadByte: The number of MadBytes to be burn should be greater than 0!");
+        _poolBalance -= _MBtoEth(_poolBalance, totalSupply(), nuMB_);
+        ERC20._burn(msg.sender, nuMB_);
+        return true;
+    }
+
+    // Internal function that does the deposit in the Madnet Chain, i.e emit the
+    // event DepositReceived. All the Madbytes sent to this function are burned.
     function _deposit(address to_, uint256 amount_) internal returns (uint256) {
         require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
         require(amount_ > 0, "MadByte: The deposit amount must be greater than zero!");
-        require(ERC20.transfer(address(this), amount_), "MadByte: Transfer failed!");
+        require(_destroyTokens(amount_), "MadByte: Burn failed during the deposit!");
         // copying state to save gas
         uint256 depositID = _depositID + 1;
         _deposits[depositID] = amount_;
@@ -192,9 +304,12 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return depositID;
     }
 
-    function _depositBN(bytes32 to0_, bytes32 to1_, bytes32 to2_, bytes32 to3_, uint256 amount_) internal returns (uint256) {
+    // Internal function that does the deposit in the Madnet Chain for user
+    // using BN addresses, i.e emit the event DepositReceivedBN. All the
+    // Madbytes sent to this function are burned.
+    function _depositBN(uint256 to0_, uint256 to1_, uint256 to2_, uint256 to3_, uint256 amount_) internal returns (uint256) {
         require(amount_ > 0, "MadByte: The deposit amount must be greater than zero!");
-        require(ERC20.transfer(address(this), amount_), "MadByte: Transfer failed!");
+        require(_destroyTokens(amount_), "MadByte: Transfer failed!");
         // copying state to save gas
         uint256 depositID = _depositID + 1;
         _deposits[depositID] = amount_;
@@ -205,6 +320,8 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return depositID;
     }
 
+    // does a virtual deposit into the Madnet Chain without actually minting or
+    // burning any token.
     function _virtualDeposit(address to_, uint256 amount_) internal returns (uint256) {
         require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
         require(amount_ > 0, "MadByte: The deposit amount must be greater than zero!");
@@ -218,6 +335,8 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return depositID;
     }
 
+    // Mints a virtual deposit into the Madnet Chain without actually minting or
+    // burning any token. This function converts ether sent in Madbytes.
     function _mintDeposit(address to_, uint256 minMB_, uint256 numEth_) internal returns (uint256) {
         require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
         require(numEth_ >= marketSpread, "MadByte: requires at least 4 WEI");
@@ -233,6 +352,8 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return depositID;
     }
 
+    // Internal function that mints the MadByte tokens following the bounding
+    // price curve.
     function _mint(address to_, uint256 numEth_, uint256 minMB_) internal returns(uint256 nuMB) {
         require(numEth_ >= marketSpread, "MadByte: requires at least 4 WEI");
         numEth_ = numEth_/marketSpread;
@@ -245,6 +366,8 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return nuMB;
     }
 
+    // Internal function that burns the MadByte tokens following the bounding
+    // price curve.
     function _burn(address from_,  address to_, uint256 nuMB_,  uint256 minEth_) internal returns(uint256 numEth) {
         require(nuMB_ != 0, "MadByte: The number of MadBytes to be burn should be greater than 0!");
         uint256 poolBalance = _poolBalance;
@@ -257,10 +380,14 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return numEth;
     }
 
+    // Internal function that converts an ether amount into MadByte tokens
+    // following the bounding price curve.
     function _EthtoMB(uint256 poolBalance_, uint256 numEth_) internal pure returns(uint256) {
       return _fx(poolBalance_ + numEth_) - _fx(poolBalance_);
     }
 
+    // Internal function that converts a MadByte amount into ether following the
+    // bounding price curve.
     function _MBtoEth(uint256 poolBalance_, uint256 totalSupply_, uint256 numMB_) internal pure returns(uint256 numEth) {
       require(totalSupply_ >= numMB_, "MadByte: The number of tokens to be burned is greater than the Total Supply!");
       return _min(poolBalance_, _fp(totalSupply_) - _fp(totalSupply_ - numMB_));

--- a/src/MadByte.sol
+++ b/src/MadByte.sol
@@ -11,12 +11,40 @@ import "./Sigmoid.sol";
 
 contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigmoid {
 
+    /// @notice Event emitted when a deposit is received
+    event DepositReceived(uint256 indexed depositID, address indexed depositor, uint256 amount);
+    event DepositReceivedBN(uint256 indexed depositID, bytes32 to0, bytes32 to1, bytes32 to2, bytes32 to3, uint256 amount);
+
     uint256 constant marketSpread = 4;
     uint256 constant madUnitOne = 1000;
     uint256 constant protocolFee = 3;
 
     uint256 _poolBalance = 0;
     uint256 _minerSplit = 500;
+
+    struct BNAddress {
+        bytes32 to0;
+        bytes32 to1;
+        bytes32 to2;
+        bytes32 to3;
+    }
+
+    // Monotonically increasing variable to track the MadBytes deposits.
+    uint256 _depositID;
+    // Total amount of MadBytes that were deposited in this contract.
+    uint256 _totalDeposited;
+
+    // Tracks the amount of each deposit. Key is deposit id, value is amount
+    // deposited.
+    mapping(uint256 => uint256) _deposits;
+    // Tracks the owner of each deposit. Key is deposit id, value is the address
+    // of the owner of a deposit.
+    mapping(uint256 => address) _depositors;
+    // Tracks the owner of each deposit. This mapping is required to keep track
+    // of owners with BN addresses. Key is deposit id, value is the BN address
+    // (4x bytes32) of owner of a deposit.
+    mapping(uint256 => BNAddress) _depositorsBN;
+
     IMagicEthTransfer _madStaking;
     IMagicEthTransfer _minerStaking;
     IMagicEthTransfer _foundation;
@@ -44,8 +72,74 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         _minerSplit = split_;
     }
 
+    function MBtoEth(uint256 poolBalance_, uint256 totalSupply_, uint256 numMB_) public pure returns(uint256 numEth) {
+      return _MBtoEth(poolBalance_, totalSupply_, numMB_);
+    }
+
+    function EthtoMB(uint256 poolBalance_, uint256 numEth_) public pure returns(uint256) {
+      return _EthtoMB(poolBalance_, numEth_);
+    }
+
+    function getPoolBalance() public view returns(uint256) {
+        return _poolBalance;
+    }
+
+    function getTotalMadBytesDeposited() public view returns(uint256) {
+        return _totalDeposited;
+    }
+
+    function getDeposit(uint256 depositID) public view returns(uint256) {
+        require(depositID <= _depositID, "MadByte: Invalid deposit ID!");
+        return _deposits[depositID];
+    }
+
+    function getDepositOwner(uint256 depositID) public view returns(address, BNAddress memory) {
+        require(depositID <= _depositID, "MadByte: Invalid deposit ID!");
+        return (_depositors[depositID], _depositorsBN[depositID]);
+    }
+
     function distribute() public returns(uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) {
         return _distribute();
+    }
+
+    function deposit(uint256 amount_) public returns (bool) {
+        return _deposit(msg.sender, amount_);
+    }
+
+    function depositTo(address to_, uint256 amount_) public returns (bool) {
+        return _deposit(to_, amount_);
+    }
+
+    function depositToBN(bytes32 to0_, bytes32 to1_, bytes32 to2_, bytes32 to3_, uint256 amount_) public returns (bool) {
+        return _depositBN(to0_, to1_, to2_, to3_, amount_);
+    }
+
+    function virtualMintDeposit(address to_, uint256 amount_) public onlyAdmin returns (bool) {
+        return _virtualDeposit(to_, amount_);
+    }
+
+    function mintDeposit(address to_, uint256 amountMin_) public payable returns (bool) {
+        return _mintDeposit(to_, amountMin_, msg.value);
+    }
+
+    function mint(uint256 minMB_) public payable returns(uint256 nuMB) {
+        nuMB = _mint(msg.sender, msg.value, minMB_);
+        return nuMB;
+    }
+
+    function mintTo(address to_, uint256 minMB_) public payable returns(uint256 nuMB) {
+        nuMB = _mint(to_, msg.value, minMB_);
+        return nuMB;
+    }
+
+    function burn(uint256 amount_, uint256 minEth_) public returns(uint256 numEth) {
+        numEth = _burn(msg.sender, msg.sender, amount_, minEth_);
+        return numEth;
+    }
+
+    function burnTo(address to_, uint256 amount_, uint256 minEth_) public returns(uint256 numEth) {
+        numEth = _burn(msg.sender, to_,  amount_, minEth_);
+        return numEth;
     }
 
     function _distribute() internal withLock returns(uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) {
@@ -76,24 +170,64 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return (foundationAmount, minerAmount, stakingAmount);
     }
 
-    function mint(uint256 minMB_) public payable returns(uint256 nuMB) {
-        nuMB = _mint(msg.sender, msg.value, minMB_);
-        return nuMB;
+    function _isContract(address addr_) internal returns (bool) {
+        uint256 size;
+        assembly{
+            size := extcodesize(addr_)
+        }
+        return size > 0;
     }
 
-    function mintTo(address to_, uint256 minMB_) public payable returns(uint256 nuMB) {
-        nuMB = _mint(to_, msg.value, minMB_);
-        return nuMB;
+    function _deposit(address to_, uint256 amount_) internal returns (bool) {
+        require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
+        require(transferFrom(msg.sender, address(this), amount_), "MadByte: Transfer failed!");
+        // copying state to save gas
+        uint256 depositID = _depositID + 1;
+        _deposits[depositID] = amount_;
+        _depositors[depositID] = to_;
+        _totalDeposited += amount_;
+        _depositID = depositID;
+        emit DepositReceived(depositID, to_, amount_);
+        return true;
     }
 
-    function burn(uint256 amount_, uint256 minEth_) public returns(uint256 numEth) {
-        numEth = _burn(msg.sender, msg.sender, amount_, minEth_);
-        return numEth;
+    function _depositBN(bytes32 to0_, bytes32 to1_, bytes32 to2_, bytes32 to3_, uint256 amount_) internal returns (bool) {
+        require(transferFrom(msg.sender, address(this), amount_), "MadByte: Transfer failed!");
+        // copying state to save gas
+        uint256 depositID = _depositID + 1;
+        _deposits[depositID] = amount_;
+        _depositorsBN[depositID] = BNAddress(to0_, to1_, to2_, to3_);
+        _totalDeposited += amount_;
+        _depositID = depositID;
+        emit DepositReceivedBN(depositID, to0_, to1_, to2_, to3_, amount_);
+        return true;
     }
 
-    function burnTo(address to_, uint256 amount_, uint256 minEth_) public returns(uint256 numEth) {
-        numEth = _burn(msg.sender, to_,  amount_, minEth_);
-        return numEth;
+    function _virtualDeposit(address to_, uint256 amount_) internal returns (bool) {
+        require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
+        // copying state to save gas
+        uint256 depositID = _depositID + 1;
+        _deposits[depositID] = amount_;
+        _depositors[depositID] = to_;
+        _totalDeposited += amount_;
+        _depositID = depositID;
+        emit DepositReceived(depositID, to_, amount_);
+        return true;
+    }
+
+    function _mintDeposit(address to_, uint256 minMB_, uint256 numEth_) internal returns (bool) {
+        require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
+        require(numEth_ >= marketSpread, "MadByte: requires at least 4 WEI");
+        numEth_ = numEth_/marketSpread;
+        uint256 amount_ = _EthtoMB(_poolBalance, numEth_);
+        require(amount_ >= minMB_, "MadByte: could not mint deposit with minimum MadBytes given the ether sent!");
+        uint256 depositID = _depositID + 1;
+        _deposits[depositID] = amount_;
+        _depositors[depositID] = to_;
+        _totalDeposited += amount_;
+        _depositID = depositID;
+        emit DepositReceived(depositID, to_, amount_);
+        return true;
     }
 
     function _mint(address to_, uint256 numEth_, uint256 minMB_) internal returns(uint256 nuMB) {
@@ -120,10 +254,6 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
         return numEth;
     }
 
-    function getPoolBalance() public view returns(uint256) {
-        return _poolBalance;
-    }
-
     function _EthtoMB(uint256 poolBalance_, uint256 numEth_) internal pure returns(uint256) {
       return _fx(poolBalance_ + numEth_) - _fx(poolBalance_);
     }
@@ -131,13 +261,5 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
     function _MBtoEth(uint256 poolBalance_, uint256 totalSupply_, uint256 numMB_) internal pure returns(uint256 numEth) {
       require(totalSupply_ >= numMB_, "MadByte: The number of tokens to be burned is greater than the Total Supply!");
       return _min(poolBalance_, _fp(totalSupply_) - _fp(totalSupply_ - numMB_));
-    }
-
-    function MBtoEth(uint256 poolBalance_, uint256 totalSupply_, uint256 numMB_) public returns(uint256 numEth) {
-      return _MBtoEth(poolBalance_, totalSupply_, numMB_);
-    }
-
-    function EthtoMB(uint256 poolBalance_, uint256 numEth_) public pure returns(uint256) {
-      return _EthtoMB(poolBalance_, numEth_);
     }
 }

--- a/src/MadByte.sol
+++ b/src/MadByte.sol
@@ -180,6 +180,7 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
 
     function _deposit(address to_, uint256 amount_) internal returns (uint256) {
         require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
+        require(amount_ > 0, "MadByte: The deposit amount must be greater than zero!");
         require(ERC20.transfer(address(this), amount_), "MadByte: Transfer failed!");
         // copying state to save gas
         uint256 depositID = _depositID + 1;
@@ -192,6 +193,7 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
     }
 
     function _depositBN(bytes32 to0_, bytes32 to1_, bytes32 to2_, bytes32 to3_, uint256 amount_) internal returns (uint256) {
+        require(amount_ > 0, "MadByte: The deposit amount must be greater than zero!");
         require(ERC20.transfer(address(this), amount_), "MadByte: Transfer failed!");
         // copying state to save gas
         uint256 depositID = _depositID + 1;
@@ -205,6 +207,7 @@ contract MadByte is ERC20, Admin, Mutex, MagicEthTransfer, EthSafeTransfer, Sigm
 
     function _virtualDeposit(address to_, uint256 amount_) internal returns (uint256) {
         require(!_isContract(to_), "MadByte: Contracts cannot make MadBytes deposits!");
+        require(amount_ > 0, "MadByte: The deposit amount must be greater than zero!");
         // copying state to save gas
         uint256 depositID = _depositID + 1;
         _deposits[depositID] = amount_;

--- a/src/MadByte.t.sol
+++ b/src/MadByte.t.sol
@@ -1080,10 +1080,10 @@ contract MadByteTest is DSTest, Sigmoid {
         (MadByte token,,,,) = getFixtureData();
         assertEq(token.getPoolBalance(), 0);
         EOA_SingleDeposit user = new EOA_SingleDeposit{value: 10 ether}(token);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), user.madBytes());
 
         assertEq(token.balanceOf(address(user)), user.madBytes());
-        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
+        assertEq(token.balanceOf(address(token)), 0);
         assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
         assertEq(token.getDeposit(1), 100 * ONE_MB);
         (address depositOwner, ) = token.getDepositOwner(1);
@@ -1094,11 +1094,11 @@ contract MadByteTest is DSTest, Sigmoid {
         (MadByte token,,,,) = getFixtureData();
         assertEq(token.getPoolBalance(), 0);
         EOA_DoubleDeposit user = new EOA_DoubleDeposit{value: 10 ether}(token);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), user.madBytes());
 
         // first deposit
         assertEq(token.balanceOf(address(user)), user.madBytes());
-        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.balanceOf(address(token)), 0);
         assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
         assertEq(token.getDeposit(1), 100 * ONE_MB);
         (address depositOwner, ) = token.getDepositOwner(1);
@@ -1106,7 +1106,7 @@ contract MadByteTest is DSTest, Sigmoid {
 
         // second deposit
         assertEq(token.balanceOf(address(user)), user.madBytes());
-        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.balanceOf(address(token)), 0);
         assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
         assertEq(token.getDeposit(2), 199 * ONE_MB);
         (address depositOwner2, ) = token.getDepositOwner(2);
@@ -1121,27 +1121,26 @@ contract MadByteTest is DSTest, Sigmoid {
         emit log_named_address("EOA Msg sender", msg.sender);
         assertEq(token.balanceOf(address(this)), madBytes);
 
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), madBytes);
         // first deposit
         uint256 depositID = token.depositTo(user, 100 * ONE_MB);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), madBytes - (100 * ONE_MB));
         assertEq(depositID, 1);
         assertEq(token.balanceOf(user), 0);
         assertEq(token.balanceOf(address(this)), madBytes - (100 * ONE_MB));
-        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
+        assertEq(token.balanceOf(address(token)), 0);
         assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
         assertEq(token.getDeposit(1), 100 * ONE_MB);
         (address depositOwner, ) = token.getDepositOwner(1);
         assertEq(depositOwner, user);
 
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
         // second deposit
         depositID = token.depositTo(user, 199 * ONE_MB);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), madBytes - (299 * ONE_MB));
         assertEq(depositID, 2);
         assertEq(token.balanceOf(user), 0);
         assertEq(token.balanceOf(address(this)), madBytes - (299 * ONE_MB));
-        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.balanceOf(address(token)), 0);
         assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
         assertEq(token.getDeposit(2), 199 * ONE_MB);
         (address depositOwner2, ) = token.getDepositOwner(2);
@@ -1150,31 +1149,31 @@ contract MadByteTest is DSTest, Sigmoid {
 
     function testDepositToBN() public {
         (MadByte token,,,,) = getFixtureData();
-        MadByte.BNAddress memory user = MadByte.BNAddress(bytes32("0x1"), bytes32("0x2"), bytes32("0x3"), bytes32("0x4"));
+        MadByte.BNAddress memory user = MadByte.BNAddress(0x1, 0x2, 0x3, 0x4);
         uint256 madBytes = token.mint{value: 10 ether}(0);
         emit log_named_uint("EOA MadBytes minted", madBytes);
         emit log_named_address("EOA Msg sender", msg.sender);
         assertEq(token.balanceOf(address(this)), madBytes);
 
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), madBytes);
         // first deposit
         uint256 depositID = token.depositToBN(user.to0, user.to1, user.to2, user.to3, 100 * ONE_MB);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), madBytes - (100 * ONE_MB));
         assertEq(depositID, 1);
         assertEq(token.balanceOf(address(this)), madBytes - (100 * ONE_MB));
-        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
+        assertEq(token.balanceOf(address(token)), 0);
         assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
         assertEq(token.getDeposit(1), 100 * ONE_MB);
         (, MadByte.BNAddress memory depositOwner) = token.getDepositOwner(1);
         assertEqBNAddress(depositOwner, user);
 
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), madBytes - (100 * ONE_MB));
         // second deposit
         depositID = token.depositToBN(user.to0, user.to1, user.to2, user.to3, 199 * ONE_MB);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(token.totalSupply(), madBytes - (299 * ONE_MB));
         assertEq(depositID, 2);
         assertEq(token.balanceOf(address(this)), madBytes - (299 * ONE_MB));
-        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.balanceOf(address(token)), 0);
         assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
         assertEq(token.getDeposit(2), 199 * ONE_MB);
         (, MadByte.BNAddress memory depositOwner2) = token.getDepositOwner(2);
@@ -1248,6 +1247,189 @@ contract MadByteTest is DSTest, Sigmoid {
 
     }
 
+    function testDistributeWithMadByteDeposit() public {
+        (
+            MadByte token,
+            ,
+            MadStakingAccount madStaking,
+            MinerStakingAccount minerStaking,
+            FoundationAccount foundation
+        ) = getFixtureData();
+
+        // assert balances
+        assertEq(address(madStaking).balance, 0);
+        assertEq(address(minerStaking).balance, 0);
+        assertEq(address(foundation).balance, 0);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(399_028731704364116575, madBytes);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(address(token).balance, 4 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+        // assert balances
+        assertEq(stakingAmount, 1495500000000000000);
+        assertEq(minerAmount, 1495500000000000000);
+        assertEq(foundationAmount, 9000000000000000);
+
+        assertEq(address(madStaking).balance, 1495500000000000000);
+        assertEq(address(minerStaking).balance, 1495500000000000000);
+        assertEq(address(foundation).balance, 9000000000000000);
+        assertEq(address(token).balance, 1 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+
+        // testing the distribute after depositing
+        address user = address(0xd39f14dCd02B9fC8A11bd95604D3E3E12Fd938EE);
+        uint256 expectedETH = token.MBtoEth(token.getPoolBalance(), token.totalSupply(), 100 * ONE_MB);
+        token.depositTo(user, 100 * ONE_MB);
+
+        (foundationAmount, minerAmount, stakingAmount) = token.distribute();
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+        assertEq(stakingAmount+minerAmount+foundationAmount, expectedETH);
+        // assert balances
+        assertEq(stakingAmount, 124928529685685073);
+        assertEq(minerAmount, 124928529685685072);
+        assertEq(foundationAmount, 751826658088375);
+
+
+        expectedETH = token.MBtoEth(token.getPoolBalance(), token.totalSupply(), 199 * ONE_MB);
+        token.depositTo(user, 199 * ONE_MB);
+
+        (foundationAmount, minerAmount, stakingAmount) = token.distribute();
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+        assertEq(stakingAmount+minerAmount+foundationAmount, expectedETH);
+        // assert balances
+        assertEq(stakingAmount, 248607411240336914);
+        assertEq(minerAmount, 248607411240336914);
+        assertEq(foundationAmount, 1496132866040141);
+    }
+
+    function testDistributeWithMadByteDepositBN() public {
+        (
+            MadByte token,
+            ,
+            MadStakingAccount madStaking,
+            MinerStakingAccount minerStaking,
+            FoundationAccount foundation
+        ) = getFixtureData();
+
+        // assert balances
+        assertEq(address(madStaking).balance, 0);
+        assertEq(address(minerStaking).balance, 0);
+        assertEq(address(foundation).balance, 0);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(399_028731704364116575, madBytes);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(address(token).balance, 4 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+        // assert balances
+        assertEq(stakingAmount, 1495500000000000000);
+        assertEq(minerAmount, 1495500000000000000);
+        assertEq(foundationAmount, 9000000000000000);
+
+        assertEq(address(madStaking).balance, 1495500000000000000);
+        assertEq(address(minerStaking).balance, 1495500000000000000);
+        assertEq(address(foundation).balance, 9000000000000000);
+        assertEq(address(token).balance, 1 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+
+        // testing the distribute after depositing
+        MadByte.BNAddress memory user = MadByte.BNAddress(0x1, 0x2, 0x3, 0x4);
+        uint256 expectedETH = token.MBtoEth(token.getPoolBalance(), token.totalSupply(), 100 * ONE_MB);
+        token.depositToBN(user.to0, user.to1, user.to2, user.to3, 100 * ONE_MB);
+
+        (foundationAmount, minerAmount, stakingAmount) = token.distribute();
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+        assertEq(stakingAmount+minerAmount+foundationAmount, expectedETH);
+        // assert balances
+        assertEq(stakingAmount, 124928529685685073);
+        assertEq(minerAmount, 124928529685685072);
+        assertEq(foundationAmount, 751826658088375);
+
+
+        expectedETH = token.MBtoEth(token.getPoolBalance(), token.totalSupply(), 199 * ONE_MB);
+        token.depositToBN(user.to0, user.to1, user.to2, user.to3, 199 * ONE_MB);
+
+        (foundationAmount, minerAmount, stakingAmount) = token.distribute();
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+        assertEq(stakingAmount+minerAmount+foundationAmount, expectedETH);
+        // assert balances
+        assertEq(stakingAmount, 248607411240336914);
+        assertEq(minerAmount, 248607411240336914);
+        assertEq(foundationAmount, 1496132866040141);
+    }
+
+    function testDistributeWithMintDeposit() public {
+        (MadByte token,,,,) = getFixtureData();
+        address user = address(0xd39f14dCd02B9fC8A11bd95604D3E3E12Fd938EE);
+        assertEq(token.getPoolBalance(), 0);
+        assertEq(token.totalSupply(), 0);
+        uint256 depositID = token.mintDeposit{value: 10 ether}(user, 0);
+        assertEq(token.getPoolBalance(), 0);
+        assertEq(token.totalSupply(), 0);
+        assertEq(depositID, 1);
+        assertEq(token.balanceOf(address(user)), 0);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(token.getTotalMadBytesDeposited(), token.getDeposit(1));
+        (address depositOwner, ) = token.getDepositOwner(depositID);
+        assertEq(depositOwner, user);
+
+        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+        assertEq(stakingAmount+minerAmount+foundationAmount, 10 ether);
+        // assert balances
+        assertEq(stakingAmount, 4985000000000000000);
+        assertEq(minerAmount, 4985000000000000000);
+        assertEq(foundationAmount, 30000000000000000);
+
+
+        uint256 depositID2 = token.mintDeposit{value: 10 ether}(user, 0);
+        assertEq(token.getPoolBalance(), 0);
+        assertEq(token.totalSupply(), 0);
+        assertEq(depositID2, 2);
+        assertEq(token.balanceOf(address(user)), 0);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(token.getTotalMadBytesDeposited(), token.getDeposit(1)+token.getDeposit(2));
+        (address depositOwner2, ) = token.getDepositOwner(depositID2);
+        assertEq(depositOwner2, user);
+
+        (foundationAmount, minerAmount, stakingAmount) = token.distribute();
+        assertEq(stakingAmount+minerAmount+foundationAmount, 10 ether);
+        // assert balances
+        assertEq(stakingAmount, 4985000000000000000);
+        assertEq(minerAmount, 4985000000000000000);
+        assertEq(foundationAmount, 30000000000000000);
+
+        assertEq(token.getDeposit(2), token.getDeposit(1));
+        emit log_named_uint("Amount deposit 1", token.getDeposit(1));
+        emit log_named_uint("Amount deposit 2", token.getDeposit(2));
+
+        // testing if we are getting the same amount of MB from the normal mint
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(token.getDeposit(1), madBytes);
+
+    }
+
     function testFail_DepositZeroMadBytes() public {
         (MadByte token,,,,) = getFixtureData();
         assertEq(token.getPoolBalance(), 0);
@@ -1269,7 +1451,7 @@ contract MadByteTest is DSTest, Sigmoid {
 
     function testFail_DepositToBNZeroMadBytes() public {
         (MadByte token,,,,) = getFixtureData();
-        MadByte.BNAddress memory user = MadByte.BNAddress(bytes32("0x1"), bytes32("0x2"), bytes32("0x3"), bytes32("0x4"));
+        MadByte.BNAddress memory user = MadByte.BNAddress(0x1, 0x2, 0x3, 0x4);
         uint256 madBytes = token.mint{value: 10 ether}(0);
         emit log_named_uint("EOA MadBytes minted", madBytes);
         emit log_named_address("EOA Msg sender", msg.sender);

--- a/src/MadByte.t.sol
+++ b/src/MadByte.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT-open-group
 pragma solidity ^0.8.0;
 
-import "../lib/ds-test/src/test.sol";
+import "ds-test/test.sol";
 
 import "./MadByte.sol";
 import "./Sigmoid.sol";

--- a/src/MadByte.t.sol
+++ b/src/MadByte.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT-open-group
 pragma solidity ^0.8.0;
 
-import "ds-test/test.sol";
+import "../lib/ds-test/src/test.sol";
 
 import "./MadByte.sol";
 import "./Sigmoid.sol";
@@ -50,6 +50,10 @@ contract AdminAccount is BaseMock {
 
     function setMinerSplit(uint256 split) public {
         token.setMinerSplit(split);
+    }
+
+    function virtualMintDeposit(address to_, uint256 amount_) public returns (uint256) {
+        return token.virtualMintDeposit(to_, amount_);
     }
 }
 
@@ -170,6 +174,50 @@ contract TokenPure {
     }
 }
 
+contract EOA_SingleDeposit is DSTest {
+    uint256 constant ONE_MB = 1*10**18;
+
+    uint256 public madBytes = 0;
+
+    // by calling the MadByte.deposit from a constructor, we make sure
+    // the extcodesize() of address(this) is zero (thanks Hunter!).
+    // this also means we can only test deposits using this approach,
+    // and asserts won't work inside this constructor
+
+    constructor(MadByte token) payable {
+        // first deposit mint
+        madBytes = token.mint{value: 10 ether}(0);
+        emit log_named_uint("EOA MadBytes minted", madBytes);
+        emit log_named_address("EOA Msg sender", msg.sender);
+        assertEq(token.balanceOf(address(this)), madBytes);
+
+        // deposit
+        uint256 depositID = token.deposit(100 * ONE_MB);
+        madBytes -= 100 * ONE_MB;
+        assertEq(depositID, 1);
+    }
+}
+
+contract EOA_DoubleDeposit is DSTest {
+    uint256 constant ONE_MB = 1*10**18;
+
+    uint256 public madBytes = 0;
+
+    constructor(MadByte token) payable {
+        // first deposit
+        // mint
+        madBytes = token.mint{value: 10 ether}(0);
+        emit log_named_uint("EOA MadBytes minted", madBytes);
+        emit log_named_address("EOA Msg sender", msg.sender);
+
+        // deposits
+        token.deposit(100 * ONE_MB);
+        madBytes -= 100 * ONE_MB;
+        token.deposit(199 * ONE_MB);
+        madBytes -= 199 * ONE_MB;
+    }
+}
+
 contract MadByteTest is DSTest, Sigmoid {
 
     uint256 constant ONE_MB = 1*10**18;
@@ -210,748 +258,1032 @@ contract MadByteTest is DSTest, Sigmoid {
         acct.setToken(token);
     }
 
+    function assertEqBNAddress(MadByte.BNAddress memory actual, MadByte.BNAddress memory expected) public {
+        assertEq(actual.to0, expected.to0);
+        assertEq(actual.to1, expected.to1);
+        assertEq(actual.to2, expected.to2);
+        assertEq(actual.to3, expected.to3);
+    }
+
     // test functions
 
-    function testFail_noAdminSetMinerStaking() public {
-        (MadByte token,,,,) = getFixtureData();
-        token.setMinerStaking(address(0x0));
-    }
+    // function testFail_noAdminSetMinerStaking() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     token.setMinerStaking(address(0x0));
+    // }
 
-    function testFail_noAdminSetMadStaking() public {
-        (MadByte token,,,,) = getFixtureData();
-        token.setMadStaking(address(0x0));
-    }
+    // function testFail_noAdminSetMadStaking() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     token.setMadStaking(address(0x0));
+    // }
 
-    function testFail_noAdminSetFoundation() public {
-        (MadByte token,,,,) = getFixtureData();
-        token.setFoundation(address(0x0));
-    }
+    // function testFail_noAdminSetFoundation() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     token.setFoundation(address(0x0));
+    // }
 
-    function testFail_noAdminSetMinerSplit() public {
-        (MadByte token,,,,) = getFixtureData();
-        token.setMinerSplit(100);
-    }
+    // function testFail_noAdminSetMinerSplit() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     token.setMinerSplit(100);
+    // }
 
-    function testAdminSetters() public {
-        (,AdminAccount admin,,,) = getFixtureData();
+    // function testAdminSetters() public {
+    //     (,AdminAccount admin,,,) = getFixtureData();
 
-        admin.setMinerStaking(address(0x0));
-        admin.setMadStaking(address(0x0));
-        admin.setFoundation(address(0x0));
-        admin.setMinerSplit(100); // 100 = 10%, 1000 = 100%
-    }
+    //     admin.setMinerStaking(address(0x0));
+    //     admin.setMadStaking(address(0x0));
+    //     admin.setFoundation(address(0x0));
+    //     admin.setMinerSplit(100); // 100 = 10%, 1000 = 100%
+    // }
 
-    function testFail_SettingMinerSplitGreaterThanMadUnitOne() public {
-        (,AdminAccount admin,,,) = getFixtureData();
-        admin.setMinerSplit(1000);
-    }
+    // function testFail_SettingMinerSplitGreaterThanMadUnitOne() public {
+    //     (,AdminAccount admin,,,) = getFixtureData();
+    //     admin.setMinerSplit(1000);
+    // }
 
-    function testMint() public {
-        (MadByte token,,,,) = getFixtureData();
+    // function testMint() public {
+    //     (MadByte token,,,,) = getFixtureData();
 
-        uint256 madBytes = token.mint{value: 4 ether}(0);
-        assertEq(madBytes, 399028731704364116575);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(address(token).balance, 4 ether);
-        assertEq(token.getPoolBalance(), 1 ether);
+    //     uint256 madBytes = token.mint{value: 4 ether}(0);
+    //     assertEq(madBytes, 399028731704364116575);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(address(token).balance, 4 ether);
+    //     assertEq(token.getPoolBalance(), 1 ether);
 
-        uint256 madBytes2 = token.mint{value: 4 ether}(0);
-        assertEq(madBytes2, 399027176702820751481);
-        assertEq(token.balanceOf(address(this)), madBytes2 + madBytes);
-        assertEq(token.totalSupply(), madBytes2 + madBytes);
-        assertEq(address(token).balance, 8 ether);
-        assertEq(token.getPoolBalance(), 2 ether);
-    }
+    //     uint256 madBytes2 = token.mint{value: 4 ether}(0);
+    //     assertEq(madBytes2, 399027176702820751481);
+    //     assertEq(token.balanceOf(address(this)), madBytes2 + madBytes);
+    //     assertEq(token.totalSupply(), madBytes2 + madBytes);
+    //     assertEq(address(token).balance, 8 ether);
+    //     assertEq(token.getPoolBalance(), 2 ether);
+    // }
 
-    function testMintExpectedBondingCurvePoints() public {
-        (MadByte token1,,,,) = getFixtureData();
-        (MadByte token2,,,,) = getFixtureData();
-        (MadByte token3,,,,) = getFixtureData();
+    // function testMintExpectedBondingCurvePoints() public {
+    //     (MadByte token1,,,,) = getFixtureData();
+    //     (MadByte token2,,,,) = getFixtureData();
+    //     (MadByte token3,,,,) = getFixtureData();
 
-        uint256 madBytes = token1.mint{value: 10_000 ether}(0);
-        assertEq(madBytes, 936764568799449143863271);
-        assertEq(token1.totalSupply(), madBytes);
-        assertEq(address(token1).balance, 10_000 ether);
-        assertEq(token1.getPoolBalance(), 2_500 ether);
+    //     uint256 madBytes = token1.mint{value: 10_000 ether}(0);
+    //     assertEq(madBytes, 936764568799449143863271);
+    //     assertEq(token1.totalSupply(), madBytes);
+    //     assertEq(address(token1).balance, 10_000 ether);
+    //     assertEq(token1.getPoolBalance(), 2_500 ether);
 
-        // at 20k ether we have a nice rounding value for madbytes generated
-        madBytes = token1.mint{value: 10_000 ether}(0);
-        assertEq(madBytes, 1005000000000000000000000 - 936764568799449143863271);
-        assertEq(token1.totalSupply(), 1005000000000000000000000);
-        assertEq(address(token1).balance, 20_000 ether);
-        assertEq(token1.getPoolBalance(), 5_000 ether);
+    //     // at 20k ether we have a nice rounding value for madbytes generated
+    //     madBytes = token1.mint{value: 10_000 ether}(0);
+    //     assertEq(madBytes, 1005000000000000000000000 - 936764568799449143863271);
+    //     assertEq(token1.totalSupply(), 1005000000000000000000000);
+    //     assertEq(address(token1).balance, 20_000 ether);
+    //     assertEq(token1.getPoolBalance(), 5_000 ether);
 
-        // the only nice value when minting happens when we mint 20k ether
-        madBytes = token2.mint{value: 20_000 ether}(0);
-        assertEq(madBytes, 1005000000000000000000000);
-        assertEq(token2.totalSupply(), madBytes);
-        assertEq(address(token2).balance, 20_000 ether);
-        assertEq(token2.getPoolBalance(), 5_000 ether);
+    //     // the only nice value when minting happens when we mint 20k ether
+    //     madBytes = token2.mint{value: 20_000 ether}(0);
+    //     assertEq(madBytes, 1005000000000000000000000);
+    //     assertEq(token2.totalSupply(), madBytes);
+    //     assertEq(address(token2).balance, 20_000 ether);
+    //     assertEq(token2.getPoolBalance(), 5_000 ether);
 
-        madBytes = token3.mint{value: 25_000 ether}(0);
-        assertEq(madBytes, 1007899288252135716968558);
-        assertEq(token3.totalSupply(), madBytes);
-        assertEq(address(token3).balance, 25_000 ether);
-        assertEq(token3.getPoolBalance(), 6_250 ether);
+    //     madBytes = token3.mint{value: 25_000 ether}(0);
+    //     assertEq(madBytes, 1007899288252135716968558);
+    //     assertEq(token3.totalSupply(), madBytes);
+    //     assertEq(address(token3).balance, 25_000 ether);
+    //     assertEq(token3.getPoolBalance(), 6_250 ether);
 
-    }
+    // }
 
-    function testMintWithBillionsOfEthereum() public {
+    // function testMintWithBillionsOfEthereum() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     // Investing trillions of US dollars in ethereum
+    //     uint256 madBytes = token.mint{value: 70_000_000_000 ether}(0);
+    //     assertEq(madBytes, 17501004975246203818081563855);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(this)), madBytes);
+    //     assertEq(address(token).balance, 70_000_000_000 ether);
+    //     assertEq(token.getPoolBalance(), 17500000000000000000000000000);
+    // }
+
+    // function testMintTo() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     UserAccount acct1 = newUserAccount(token);
+    //     UserAccount acct2 = newUserAccount(token);
+    //     uint256 madBytes = token.mintTo{value: 4 ether}(address(acct1), 0);
+    //     assertEq(madBytes, 399028731704364116575);
+    //     assertEq(token.balanceOf(address(acct1)), 399028731704364116575);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(address(token).balance, 4 ether);
+    //     assertEq(token.getPoolBalance(), 1 ether);
+
+    //     uint256 madBytes2 = token.mintTo{value: 4 ether}(address(acct2), 0);
+    //     assertEq(madBytes2, 399027176702820751481);
+    //     assertEq(token.balanceOf(address(acct2)), 399027176702820751481);
+    //     assertEq(token.totalSupply(), madBytes + madBytes2);
+    //     assertEq(address(token).balance, 8 ether);
+    //     assertEq(token.getPoolBalance(), 2 ether);
+    // }
+
+    // function testMintToWithBillionsOfEthereum() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount user = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(user).balance, 0 ether);
+    //     // Investing trillions of US dollars in ethereum
+    //     uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(user), 0);
+    //     assertEq(madBytes, 17501004975246203818081563855);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(user)), madBytes);
+    //     assertEq(address(token).balance, 70_000_000_000 ether);
+    //     assertEq(token.getPoolBalance(), 17500000000000000000000000000);
+    // }
+
+    // function testFail_MintToZeroAddress() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     UserAccount acct1 = newUserAccount(token);
+    //     UserAccount acct2 = newUserAccount(token);
+    //     token.mintTo{value: 4 ether}(address(0), 0);
+    // }
+
+    // function testFail_MintToBigMinMBQuantity() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     UserAccount acct1 = newUserAccount(token);
+    //     UserAccount acct2 = newUserAccount(token);
+    //     token.mintTo{value: 4 ether}(address(acct1), 900*ONE_MB);
+    // }
+
+    // function testTransfer() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     UserAccount acct1 = newUserAccount(token);
+    //     UserAccount acct2 = newUserAccount(token);
+
+    //     // mint and transfer some tokens to the accounts
+    //     uint256 madBytes = token.mint{value: 4 ether}(0);
+    //     assertEq(madBytes, 399_028731704364116575);
+    //     token.transfer(address(acct1), 2*ONE_MB);
+
+    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
+    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(initialBalance1, 2*ONE_MB);
+    //     assertEq(initialBalance2, 0);
+
+    //     acct1.transfer(address(acct2), ONE_MB);
+
+    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
+    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
+    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+    //     assertEq(finalBalance1, ONE_MB);
+    //     assertEq(finalBalance2, ONE_MB);
+    // }
+
+    // function testTransferFrom() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     UserAccount acct1 = newUserAccount(token);
+    //     UserAccount acct2 = newUserAccount(token);
+
+    //     // mint and transfer some tokens to the accounts
+    //     uint256 madBytes = token.mint{value: 4 ether}(0);
+    //     assertEq(madBytes, 399_028731704364116575);
+    //     token.transfer(address(acct1), 2*ONE_MB);
+
+    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
+    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(initialBalance1, 2*ONE_MB);
+    //     assertEq(initialBalance2, 0);
+
+    //     acct1.approve(address(this), ONE_MB);
+
+    //     token.transferFrom(address(acct1), address(acct2), ONE_MB);
+
+    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
+    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
+    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+    //     assertEq(finalBalance1, ONE_MB);
+    //     assertEq(finalBalance2, ONE_MB);
+    // }
+
+    // function testFail_TransferFromWithoutAllowance() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     UserAccount acct1 = newUserAccount(token);
+    //     UserAccount acct2 = newUserAccount(token);
+
+    //     // mint and transfer some tokens to the accounts
+    //     uint256 madBytes = token.mint{value: 4 ether}(0);
+    //     assertEq(madBytes, 399_028731704364116575);
+    //     token.transfer(address(acct1), 2*ONE_MB);
+
+    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
+    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(initialBalance1, 2*ONE_MB);
+    //     assertEq(initialBalance2, 0);
+
+    //     token.transferFrom(address(acct1), address(acct2), ONE_MB);
+
+    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
+    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
+    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+    //     assertEq(finalBalance1, ONE_MB);
+    //     assertEq(finalBalance2, ONE_MB);
+    // }
+
+    // function testFail_TransferMoreThanAllowance() public {
+    //     (MadByte token,,,,) = getFixtureData();
+    //     UserAccount acct1 = newUserAccount(token);
+    //     UserAccount acct2 = newUserAccount(token);
+
+    //     // mint and transfer some tokens to the accounts
+    //     uint256 madBytes = token.mint{value: 4 ether}(0);
+    //     assertEq(madBytes, 399_028731704364116575);
+    //     token.transfer(address(acct1), 2*ONE_MB);
+
+    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
+    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(initialBalance1, 2*ONE_MB);
+    //     assertEq(initialBalance2, 0);
+
+    //     acct1.approve(address(this), ONE_MB/2);
+    //     token.transferFrom(address(acct1), address(acct2), ONE_MB);
+
+    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
+    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
+    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+    //     assertEq(finalBalance1, ONE_MB);
+    //     assertEq(finalBalance2, ONE_MB);
+    // }
+
+    // function testDistribute() public {
+    //     (
+    //         MadByte token,
+    //         ,
+    //         MadStakingAccount madStaking,
+    //         MinerStakingAccount minerStaking,
+    //         FoundationAccount foundation
+    //     ) = getFixtureData();
+
+    //     // assert balances
+    //     assertEq(address(madStaking).balance, 0);
+    //     assertEq(address(minerStaking).balance, 0);
+    //     assertEq(address(foundation).balance, 0);
+
+    //     // mint and transfer some tokens to the accounts
+    //     uint256 madBytes = token.mint{value: 4 ether}(0);
+    //     assertEq(399_028731704364116575, madBytes);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(address(token).balance, 4 ether);
+    //     assertEq(token.getPoolBalance(), 1 ether);
+
+    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+    //     (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+
+    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+    //     // assert balances
+    //     assertEq(stakingAmount, 1495500000000000000);
+    //     assertEq(minerAmount, 1495500000000000000);
+    //     assertEq(foundationAmount, 9000000000000000);
+
+    //     assertEq(address(madStaking).balance, 1495500000000000000);
+    //     assertEq(address(minerStaking).balance, 1495500000000000000);
+    //     assertEq(address(foundation).balance, 9000000000000000);
+    //     assertEq(address(token).balance, 1 ether);
+    //     assertEq(token.getPoolBalance(), 1 ether);
+    // }
+
+    // function testDistributeWithMoreEthereum() public {
+    //     (
+    //         MadByte token,
+    //         ,
+    //         MadStakingAccount madStaking,
+    //         MinerStakingAccount minerStaking,
+    //         FoundationAccount foundation
+    //     ) = getFixtureData();
+
+    //     // assert balances
+    //     assertEq(address(madStaking).balance, 0);
+    //     assertEq(address(minerStaking).balance, 0);
+    //     assertEq(address(foundation).balance, 0);
+    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+    //     // mint and transfer some tokens to the accounts
+    //     uint256 madBytes = token.mint{value: 400 ether}(0);
+    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+    //     assertEq(madBytes, 39894_868089775762639314);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(address(token).balance, 400 ether);
+    //     assertEq(token.getPoolBalance(), 100 ether);
+
+    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+    //     (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+    //     // assert balances
+    //     assertEq(stakingAmount, 149550000000000000000);
+    //     assertEq(minerAmount, 149550000000000000000);
+    //     assertEq(foundationAmount, 900000000000000000);
+
+    //     assertEq(address(madStaking).balance, 149550000000000000000);
+    //     assertEq(address(minerStaking).balance, 149550000000000000000);
+    //     assertEq(address(foundation).balance, 900000000000000000);
+    //     assertEq(address(token).balance, 100 ether);
+    //     assertEq(token.getPoolBalance(), 100 ether);
+    // }
+
+    // function testFail_DistributeReEntrant() public {
+    //     (
+    //         MadByte token,
+    //         AdminAccount admin,
+    //         MadStakingAccount madStaking,
+    //         MinerStakingAccount minerStaking,
+    //         FoundationAccount foundation
+    //     ) = getFixtureData();
+
+    //     HackerAccountDistributeReEntry hacker = new HackerAccountDistributeReEntry();
+    //     hacker.setToken(token);
+    //     admin.setFoundation(address(hacker));
+    //     // assert balances
+    //     assertEq(address(madStaking).balance, 0);
+    //     assertEq(address(minerStaking).balance, 0);
+    //     assertEq(address(foundation).balance, 0);
+
+    //     // mint and transfer some tokens to the accounts
+    //     uint256 madBytes = token.mint{value: 400 ether}(0);
+    //     assertEq(madBytes, 39894_868089775762639314);
+
+    //     (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+    // }
+
+    // function testBurn() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount user = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(user).balance, 0 ether);
+    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(user)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     uint256 ethReceived = user.burn(madBytes - 100*ONE_MB);
+    //     assertEq(ethReceived, 9_749391845405398553);
+    //     assertEq(address(user).balance, ethReceived);
+    //     assertEq(token.totalSupply(), 100*ONE_MB);
+    //     assertEq(token.balanceOf(address(user)), 100*ONE_MB);
+    //     assertEq(address(token).balance, 40 ether - ethReceived);
+    //     assertEq(token.getPoolBalance(), 10 ether - ethReceived);
+    //     ethReceived = user.burn(100*ONE_MB);
+    //     assertEq(ethReceived, 10 ether - 9_749391845405398553);
+    //     assertEq(address(user).balance, 10 ether);
+    //     assertEq(address(token).balance, 30 ether);
+    //     assertEq(token.balanceOf(address(user)), 0);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(token.getPoolBalance(), 0);
+    //     token.distribute();
+    //     assertEq(address(token).balance, 0);
+    // }
+
+    // function testBurnBillionsOfMadBytes() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount user = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(user).balance, 0 ether);
+    //     // Investing trillions of US dollars in ethereum
+    //     uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(this), 0);
+    //     assertEq(madBytes, 17501004975246203818081563855);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(this)), madBytes);
+    //     assertEq(address(token).balance, 70_000_000_000 ether);
+    //     assertEq(token.getPoolBalance(), 17500000000000000000000000000);
+    //     uint256 ethReceived = token.burnTo(address(user), madBytes, 0);
+    // }
+
+    // function testFail_BurnMoreThanPossible() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount user = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(user).balance, 0 ether);
+    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(user)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     // trying to burn more than the max supply
+    //     user.burn(madBytes + 100*ONE_MB);
+    // }
+
+    // function testFail_BurnZeroMBTokens() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount user = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(user).balance, 0 ether);
+    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(user)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     user.burn(0);
+    // }
+
+    // function testBurnTo() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount userTo = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(userTo).balance, 0 ether);
+    //     uint256 madBytes = token.mint{value: 40 ether}(0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(this)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     uint256 ethReceived = token.burnTo(address(userTo), madBytes - 100*ONE_MB, 0);
+    //     assertEq(ethReceived, 9_749391845405398553);
+    //     assertEq(address(userTo).balance, ethReceived);
+    //     assertEq(token.totalSupply(), 100*ONE_MB);
+    //     assertEq(token.balanceOf(address(this)), 100*ONE_MB);
+    //     assertEq(address(token).balance, 40 ether - ethReceived);
+    //     assertEq(token.getPoolBalance(), 10 ether - ethReceived);
+    // }
+
+    // function testFail_BurnToMoreThanPossible() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount userTo = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(userTo).balance, 0 ether);
+    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(this)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     // trying to burn more than the max supply
+    //     token.burnTo(address(userTo), madBytes + 100*ONE_MB, 0);
+    // }
+
+    // function testFail_BurnToZeroMBTokens() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount userTo = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(userTo).balance, 0 ether);
+    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(this)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     token.burnTo(address(userTo), 0, 0);
+    // }
+
+    // function testFail_BurnToZeroAddress() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount userTo = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(userTo).balance, 0 ether);
+    //     uint256 madBytes = token.mint{value: 40 ether}(0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(this)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     token.burnTo(address(0), madBytes, 0);
+    // }
+
+    // function testFail_BurnWithBigMinEthAmount() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount userTo = newUserAccount(token);
+    //     assertEq(token.totalSupply(), 0);
+    //     assertEq(address(token).balance, 0 ether);
+    //     assertEq(address(userTo).balance, 0 ether);
+    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token.totalSupply(), madBytes);
+    //     assertEq(token.balanceOf(address(this)), madBytes);
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(token.getPoolBalance(), 10 ether);
+    //     // trying to burn more than the max supply
+    //     token.burnTo(address(userTo), 100*ONE_MB, 40 ether);
+    // }
+
+    // function testBurnReEntrant() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     HackerAccountBurnReEntry hacker = new HackerAccountBurnReEntry();
+    //     hacker.setToken(token);
+    //     // assert balances
+    //     assertEq(token.totalSupply(), 0);
+
+    //     // mint some tokens to the accounts
+    //     uint256 madBytesHacker = token.mintTo{value: 40 ether}(address(hacker), 0);
+    //     assertEq(madBytesHacker, 3990_217121585928137263);
+    //     assertEq(token.balanceOf(address(hacker)), madBytesHacker);
+    //     // Transferring the excess to get only 100 MD on the hacker account to make checks easier
+    //     hacker.transfer(address(this), madBytesHacker - 100*ONE_MB);
+    //     assertEq(token.balanceOf(address(hacker)), 100*ONE_MB);
+    //     emit log_named_uint("MadNet balance hacker:", token.balanceOf(address(hacker)));
+
+    //     assertEq(address(token).balance, 40 ether);
+    //     assertEq(address(hacker).balance, 0 ether);
+
+    //     // burning with reentrancy 5 times
+    //     uint256 ethReceivedHacker = hacker.burn(20*ONE_MB);
+
+    //     assertEq(token.balanceOf(address(hacker)), 0*ONE_MB);
+    //     assertEq(address(hacker).balance, 250617721342188290);
+    //     emit log_named_uint("Real Hacker Balance ETH", address(hacker).balance);
+
+    //     // If this check fails we had a reentrancy issue
+    //     assertEq(address(token).balance, 39_749382278657811710);
+
+    //     // testing a honest user
+    //     ( MadByte token2, , , , ) = getFixtureData();
+    //     assertEq(token2.totalSupply(), 0);
+    //     UserAccount honestUser = newUserAccount(token2);
+    //     uint256 madBytes = token2.mintTo{value: 40 ether}(address(honestUser), 0);
+    //     assertEq(madBytes, 3990_217121585928137263);
+    //     assertEq(token2.balanceOf(address(honestUser)), madBytes);
+    //     // Transferring the excess to get only 100 MD on the hacker account to make checks easier
+    //     honestUser.transfer(address(this), madBytes - 100*ONE_MB);
+    //     assertEq(address(token2).balance, 40 ether);
+    //     assertEq(address(honestUser).balance, 0 ether);
+    //     emit log_named_uint("Initial MadNet balance honestUser:", token2.balanceOf(address(honestUser)));
+
+    //     uint256 totalBurnt = 0;
+    //     for (uint256 i=0; i<5; i++){
+    //         totalBurnt += honestUser.burn(20*ONE_MB);
+    //     }
+    //     // the honest user must have the same balance as the hacker
+    //     assertEq(token2.balanceOf(address(honestUser)), 0);
+    //     assertEq(address(honestUser).balance, address(hacker).balance);
+    //     assertEq(address(token2).balance, address(token).balance);
+    //     emit log_named_uint("Honest Balance ETH", address(honestUser).balance);
+    // }
+
+    // function testMarketSpreadWithMintAndBurn() public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+
+    //     UserAccount user = newUserAccount(token);
+    //     uint256 supply = token.totalSupply();
+    //     assertEq(supply, 0);
+
+    //     // mint
+    //     uint256 mintedTokens = user.mint{value: 40 ether}(0);
+    //     assertEq(mintedTokens, token.balanceOf(address(user)));
+
+    //     // burn
+    //     uint256 receivedEther = user.burn(mintedTokens);
+    //     assertEq(receivedEther, 10 ether);
+    // }
+
+    // function test_MintAndBurnALotThanBurnEverything(uint96 amountETH) public {
+    //     if (amountETH == 0) {
+    //         return;
+    //     }
+    //     uint256 maxIt = 10;
+    //     if (amountETH <= maxIt) {
+    //         amountETH = amountETH+uint96(maxIt)**2+1;
+    //     }
+    //     TokenPure token = new TokenPure();
+    //     uint256 initialMB = token.mint(amountETH);
+    //     emit log_named_uint("Initial supply:    ", token.totalSupply());
+    //     uint256 madBytes = token.mint(amountETH);
+    //     emit log_named_uint("Mb generated 2:   ", madBytes);
+    //     emit log_named_uint("Initial supply2:   ", token.totalSupply());
+
+    //     uint256 cumulativeMBBurned = 0;
+    //     uint256 cumulativeMBMinted = 0;
+    //     uint256 cumulativeETHBurned = 0;
+    //     uint256 cumulativeETHMinted = 0;
+    //     uint256 amountBurned = madBytes/maxIt;
+    //     uint256 amountMinted = amountETH/10000;
+    //     if (amountMinted == 0) {
+    //         amountMinted=1;
+    //     }
+    //     for (uint256 i=0; i<maxIt; i++) {
+    //         amountBurned = _min(amountBurned, token.totalSupply());
+    //         cumulativeETHBurned += token.burn(amountBurned);
+    //         cumulativeMBBurned += amountBurned;
+    //         cumulativeMBMinted += token.mint(amountMinted);
+    //         cumulativeETHMinted += amountMinted;
+    //     }
+    //     int256 burnedMBDiff = int256(cumulativeMBBurned)-int256(cumulativeMBMinted);
+    //     if (burnedMBDiff < 0) {
+    //         burnedMBDiff *= -1;
+    //     }
+    //     uint256 burnedETH = token.burn(token.totalSupply());
+
+    //     emit log("=======================================================");
+    //     emit log_named_uint("Token Balance:    ", token.totalSupply());
+    //     emit log_named_uint("amountMinted ETH   ", amountMinted);
+    //     emit log_named_uint("amountBurned       ", amountBurned);
+    //     emit log_named_uint("cumulativeMBBurned ", cumulativeMBBurned);
+    //     emit log_named_uint("cumulativeMBMinted ", cumulativeMBMinted);
+    //     emit log_named_uint("cumulativeETHBurned", cumulativeETHBurned);
+    //     emit log_named_uint("cumulativeETHMinted", cumulativeETHMinted);
+    //     emit log_named_int("Diff MB after loop ", burnedMBDiff);
+    //     emit log_named_uint("Final ETH burned   ", burnedETH);
+    //     emit log_named_uint("Token1 Balance:    ", token.poolBalance());
+    //     emit log_named_uint("Token1 supply:     ", token.totalSupply());
+    //     assertTrue(token.poolBalance() >= 0);
+    //     assertEq(token.totalSupply(), 0);
+    // }
+
+    // function test_ConversionMBToEthAndEthMBFunctions(uint96 amountEth) public {
+    //     ( MadByte token, , , , ) = getFixtureData();
+
+    //     if (amountEth == 0) {
+    //         return;
+    //     }
+    //     uint256 poolBalance = amountEth;
+    //     uint256 totalSupply = token.EthtoMB(0, amountEth);
+    //     uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
+    //     uint256 totalSupplyAfter = _fx(poolBalanceAfter);
+    //     uint256 mb = totalSupply - totalSupplyAfter;
+    //     uint256 returnedEth = token.MBtoEth(poolBalance, totalSupply, mb);
+    //     emit log_named_uint("Diff:", poolBalance - returnedEth);
+    //     assertTrue(poolBalance - returnedEth == poolBalanceAfter);
+    // }
+
+    // function test_ConversionMBToEthAndEthMBToken(uint96 amountEth) public {
+    //     TokenPure token = new TokenPure();
+    //     if (amountEth == 0) {
+    //         return;
+    //     }
+    //     uint256 totalSupply = token.mint(amountEth);
+    //     uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
+    //     uint256 totalSupplyAfter = _fx(poolBalanceAfter);
+    //     uint256 mb = totalSupply - totalSupplyAfter;
+    //     uint256 poolBalanceBeforeBurn = token.poolBalance();
+    //     uint256 returnedEth = token.burn(mb);
+    //     emit log_named_uint("Tt supply after", totalSupplyAfter);
+    //     emit log_named_uint("MB burned      ", mb);
+    //     emit log_named_uint("Pool balance   ", poolBalanceBeforeBurn);
+    //     emit log_named_uint("Pool After     ", poolBalanceAfter);
+    //     emit log_named_uint("returnedEth    ", returnedEth);
+    //     emit log_named_uint("Diff           ", poolBalanceBeforeBurn - returnedEth);
+    //     emit log_named_uint("ExpectedDiff   ", poolBalanceAfter);
+    //     emit log_named_int("Delta          ", int256(poolBalanceAfter) - int256(poolBalanceBeforeBurn - returnedEth));
+    //     assertTrue(poolBalanceBeforeBurn - returnedEth == poolBalanceAfter);
+    // }
+
+    // function testInvariantHold() public {
+    //     /*
+    //     tests if the invariant holds with mint and burn:
+    //     ethIn / burn(mint(ethIn)) >= marketSpread;
+    //     */
+
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount user = newUserAccount(token);
+    //     UserAccount user2 = newUserAccount(token);
+
+    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+    //     uint256 ethReceived = user.burn(madBytes);
+
+    //     assertTrue(40 ether / ethReceived >= 4);
+
+    //     madBytes = token.mintTo{value: 40 ether}(address(user2), 0);
+    //     ethReceived = user2.burn(madBytes);
+
+    //     assertTrue(40 ether / ethReceived >= 4);
+
+    //     madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+    //     uint256 madBytes2 = token.mintTo{value: 40 ether}(address(user2), 0);
+    //     uint256 ethReceived2 = user2.burn(madBytes2);
+    //     ethReceived = user.burn(madBytes);
+
+    //     emit log_named_uint("inv1.1:", 40 ether / ethReceived);
+    //     emit log_named_uint("inv1.2:", 40 ether / ethReceived2);
+
+    //     assertTrue(40 ether / ethReceived >= 4);
+    //     assertTrue(40 ether / ethReceived2 >= 4);
+
+    //     // amounts that are not multiple of 4
+    //     madBytes = token.mintTo{value: 53 ether}(address(user), 0);
+    //     madBytes2 = token.mintTo{value: 53 ether}(address(user2), 0);
+    //     ethReceived2 = user2.burn(madBytes2);
+    //     ethReceived = user.burn(madBytes);
+
+    //     emit log_named_uint("inv1.1:", 53 ether / ethReceived);
+    //     emit log_named_uint("inv1.2:", 53 ether / ethReceived2);
+
+    //     assertTrue(53 ether / ethReceived >= 4);
+    //     assertTrue(53 ether / ethReceived2 >= 4);
+    // }
+
+    // function testInvariantHold2() public {
+    //     /*
+    //     tests if the invariant holds with mint and burn:
+    //     ethIn / burn(mint(ethIn)) >= marketSpread;
+    //     */
+
+    //     ( MadByte token, , , , ) = getFixtureData();
+    //     UserAccount user = newUserAccount(token);
+    //     UserAccount user2 = newUserAccount(token);
+
+    //     uint256 madBytes = token.mintTo{value: 4*2000 ether}(address(user), 0);
+    //     uint256 ethReceived = user.burn(madBytes);
+
+    //     emit log_named_uint("inv3:", 2000 ether / ethReceived);
+    //     assertTrue(4*2000 ether / ethReceived >= 4);
+
+    // }
+
+    function testFail_QueryNonexistingDepositId() public {
         ( MadByte token, , , , ) = getFixtureData();
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        // Investing trillions of US dollars in ethereum
-        uint256 madBytes = token.mint{value: 70_000_000_000 ether}(0);
-        assertEq(madBytes, 17501004975246203818081563855);
-        assertEq(token.totalSupply(), madBytes);
+        token.getDeposit(1000);
+    }
+
+    function testFail_GetOwnerWithNonexistingDepositId() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        token.getDepositOwner(1000);
+    }
+
+    function testFail_DepositToContract() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        // contracting simulating an user
+        UserAccount user1 = newUserAccount(token);
+        token.depositTo(address(user1), 10 * ONE_MB);
+
+    }
+
+    function testFail_DepositContract() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        token.deposit(10 * ONE_MB);
+    }
+
+    function testFail_virtualMintDepositContract() public {
+        ( MadByte token, AdminAccount admin , , , ) = getFixtureData();
+        uint256 madBytes = token.mintTo{value: 10 ether}(address(admin), 0);
+        // contracting simulating an user
+        UserAccount user1 = newUserAccount(token);
+        admin.virtualMintDeposit(address(user1), 10 * ONE_MB);
+    }
+
+    function testFail_MintDepositContract() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        uint256 madBytes = token.mintDeposit{value: 10 ether}(address(this), 0);
+    }
+
+    function testFail_DepositWithoutFunds() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        token.depositTo(address(0xd39f14dCd02B9fC8A11bd95604D3E3E12Fd938EE), 1000 * ONE_MB);
+    }
+
+    function testFail_noAdminVirtualMintDeposit() public {
+        (MadByte token,,,,) = getFixtureData();
+        token.virtualMintDeposit(address(0x0), 100);
+    }
+
+    function testMakeDepositTo() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        address user = 0x00a329c0648769A73afAc7F9381E08FB43dBEA72;
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        emit log_named_uint("MadBytes minted", madBytes);
         assertEq(token.balanceOf(address(this)), madBytes);
-        assertEq(address(token).balance, 70_000_000_000 ether);
-        assertEq(token.getPoolBalance(), 17500000000000000000000000000);
+
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        uint256 depositID = token.depositTo(user, 100 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 1);
+        assertEq(token.balanceOf(address(this)), madBytes - 100 * ONE_MB);
+        assertEq(token.balanceOf(user), 0);
+        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
+        assertEq(token.getDeposit(depositID), 100 * ONE_MB);
+        (address depositOwner, ) = token.getDepositOwner(depositID);
+        assertEq(depositOwner, user);
+
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        uint256 depositID2 = token.depositTo(user, 199 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID2, 2);
+        assertEq(token.balanceOf(address(this)), madBytes - 299 * ONE_MB);
+        assertEq(token.balanceOf(user), 0);
+        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
+        assertEq(token.getDeposit(depositID2), 199 * ONE_MB);
+        (address depositOwner2, ) = token.getDepositOwner(depositID2);
+        assertEq(depositOwner2, user);
     }
 
-    function testMintTo() public {
+    function testSingleDeposit() public {
         (MadByte token,,,,) = getFixtureData();
-        UserAccount acct1 = newUserAccount(token);
-        UserAccount acct2 = newUserAccount(token);
-        uint256 madBytes = token.mintTo{value: 4 ether}(address(acct1), 0);
-        assertEq(madBytes, 399028731704364116575);
-        assertEq(token.balanceOf(address(acct1)), 399028731704364116575);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(address(token).balance, 4 ether);
-        assertEq(token.getPoolBalance(), 1 ether);
-
-        uint256 madBytes2 = token.mintTo{value: 4 ether}(address(acct2), 0);
-        assertEq(madBytes2, 399027176702820751481);
-        assertEq(token.balanceOf(address(acct2)), 399027176702820751481);
-        assertEq(token.totalSupply(), madBytes + madBytes2);
-        assertEq(address(token).balance, 8 ether);
-        assertEq(token.getPoolBalance(), 2 ether);
-    }
-
-    function testMintToWithBillionsOfEthereum() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount user = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(user).balance, 0 ether);
-        // Investing trillions of US dollars in ethereum
-        uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(user), 0);
-        assertEq(madBytes, 17501004975246203818081563855);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(token.balanceOf(address(user)), madBytes);
-        assertEq(address(token).balance, 70_000_000_000 ether);
-        assertEq(token.getPoolBalance(), 17500000000000000000000000000);
-    }
-
-    function testFail_MintToZeroAddress() public {
-        (MadByte token,,,,) = getFixtureData();
-        UserAccount acct1 = newUserAccount(token);
-        UserAccount acct2 = newUserAccount(token);
-        token.mintTo{value: 4 ether}(address(0), 0);
-    }
-
-    function testFail_MintToBigMinMBQuantity() public {
-        (MadByte token,,,,) = getFixtureData();
-        UserAccount acct1 = newUserAccount(token);
-        UserAccount acct2 = newUserAccount(token);
-        token.mintTo{value: 4 ether}(address(acct1), 900*ONE_MB);
-    }
-
-    function testTransfer() public {
-        (MadByte token,,,,) = getFixtureData();
-        UserAccount acct1 = newUserAccount(token);
-        UserAccount acct2 = newUserAccount(token);
-
-        // mint and transfer some tokens to the accounts
-        uint256 madBytes = token.mint{value: 4 ether}(0);
-        assertEq(madBytes, 399_028731704364116575);
-        token.transfer(address(acct1), 2*ONE_MB);
-
-        uint256 initialBalance1 = token.balanceOf(address(acct1));
-        uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(initialBalance1, 2*ONE_MB);
-        assertEq(initialBalance2, 0);
-
-        acct1.transfer(address(acct2), ONE_MB);
-
-        uint256 finalBalance1 = token.balanceOf(address(acct1));
-        uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(finalBalance1, initialBalance1-ONE_MB);
-        assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-        assertEq(finalBalance1, ONE_MB);
-        assertEq(finalBalance2, ONE_MB);
-    }
-
-    function testTransferFrom() public {
-        (MadByte token,,,,) = getFixtureData();
-        UserAccount acct1 = newUserAccount(token);
-        UserAccount acct2 = newUserAccount(token);
-
-        // mint and transfer some tokens to the accounts
-        uint256 madBytes = token.mint{value: 4 ether}(0);
-        assertEq(madBytes, 399_028731704364116575);
-        token.transfer(address(acct1), 2*ONE_MB);
-
-        uint256 initialBalance1 = token.balanceOf(address(acct1));
-        uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(initialBalance1, 2*ONE_MB);
-        assertEq(initialBalance2, 0);
-
-        acct1.approve(address(this), ONE_MB);
-
-        token.transferFrom(address(acct1), address(acct2), ONE_MB);
-
-        uint256 finalBalance1 = token.balanceOf(address(acct1));
-        uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(finalBalance1, initialBalance1-ONE_MB);
-        assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-        assertEq(finalBalance1, ONE_MB);
-        assertEq(finalBalance2, ONE_MB);
-    }
-
-    function testFail_TransferFromWithoutAllowance() public {
-        (MadByte token,,,,) = getFixtureData();
-        UserAccount acct1 = newUserAccount(token);
-        UserAccount acct2 = newUserAccount(token);
-
-        // mint and transfer some tokens to the accounts
-        uint256 madBytes = token.mint{value: 4 ether}(0);
-        assertEq(madBytes, 399_028731704364116575);
-        token.transfer(address(acct1), 2*ONE_MB);
-
-        uint256 initialBalance1 = token.balanceOf(address(acct1));
-        uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(initialBalance1, 2*ONE_MB);
-        assertEq(initialBalance2, 0);
-
-        token.transferFrom(address(acct1), address(acct2), ONE_MB);
-
-        uint256 finalBalance1 = token.balanceOf(address(acct1));
-        uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(finalBalance1, initialBalance1-ONE_MB);
-        assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-        assertEq(finalBalance1, ONE_MB);
-        assertEq(finalBalance2, ONE_MB);
-    }
-
-    function testFail_TransferMoreThanAllowance() public {
-        (MadByte token,,,,) = getFixtureData();
-        UserAccount acct1 = newUserAccount(token);
-        UserAccount acct2 = newUserAccount(token);
-
-        // mint and transfer some tokens to the accounts
-        uint256 madBytes = token.mint{value: 4 ether}(0);
-        assertEq(madBytes, 399_028731704364116575);
-        token.transfer(address(acct1), 2*ONE_MB);
-
-        uint256 initialBalance1 = token.balanceOf(address(acct1));
-        uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(initialBalance1, 2*ONE_MB);
-        assertEq(initialBalance2, 0);
-
-        acct1.approve(address(this), ONE_MB/2);
-        token.transferFrom(address(acct1), address(acct2), ONE_MB);
-
-        uint256 finalBalance1 = token.balanceOf(address(acct1));
-        uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-        assertEq(finalBalance1, initialBalance1-ONE_MB);
-        assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-        assertEq(finalBalance1, ONE_MB);
-        assertEq(finalBalance2, ONE_MB);
-    }
-
-    function testDistribute() public {
-        (
-            MadByte token,
-            ,
-            MadStakingAccount madStaking,
-            MinerStakingAccount minerStaking,
-            FoundationAccount foundation
-        ) = getFixtureData();
-
-        // assert balances
-        assertEq(address(madStaking).balance, 0);
-        assertEq(address(minerStaking).balance, 0);
-        assertEq(address(foundation).balance, 0);
-
-        // mint and transfer some tokens to the accounts
-        uint256 madBytes = token.mint{value: 4 ether}(0);
-        assertEq(399_028731704364116575, madBytes);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(address(token).balance, 4 ether);
-        assertEq(token.getPoolBalance(), 1 ether);
-
-        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-
-        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
-
-        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-
-        // assert balances
-        assertEq(stakingAmount, 1495500000000000000);
-        assertEq(minerAmount, 1495500000000000000);
-        assertEq(foundationAmount, 9000000000000000);
-
-        assertEq(address(madStaking).balance, 1495500000000000000);
-        assertEq(address(minerStaking).balance, 1495500000000000000);
-        assertEq(address(foundation).balance, 9000000000000000);
-        assertEq(address(token).balance, 1 ether);
-        assertEq(token.getPoolBalance(), 1 ether);
-    }
-
-    function testDistributeWithMoreEthereum() public {
-        (
-            MadByte token,
-            ,
-            MadStakingAccount madStaking,
-            MinerStakingAccount minerStaking,
-            FoundationAccount foundation
-        ) = getFixtureData();
-
-        // assert balances
-        assertEq(address(madStaking).balance, 0);
-        assertEq(address(minerStaking).balance, 0);
-        assertEq(address(foundation).balance, 0);
-        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-        // mint and transfer some tokens to the accounts
-        uint256 madBytes = token.mint{value: 400 ether}(0);
-        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-        assertEq(madBytes, 39894_868089775762639314);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(address(token).balance, 400 ether);
-        assertEq(token.getPoolBalance(), 100 ether);
-
-        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
-        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-
-        // assert balances
-        assertEq(stakingAmount, 149550000000000000000);
-        assertEq(minerAmount, 149550000000000000000);
-        assertEq(foundationAmount, 900000000000000000);
-
-        assertEq(address(madStaking).balance, 149550000000000000000);
-        assertEq(address(minerStaking).balance, 149550000000000000000);
-        assertEq(address(foundation).balance, 900000000000000000);
-        assertEq(address(token).balance, 100 ether);
-        assertEq(token.getPoolBalance(), 100 ether);
-    }
-
-    function testFail_DistributeReEntrant() public {
-        (
-            MadByte token,
-            AdminAccount admin,
-            MadStakingAccount madStaking,
-            MinerStakingAccount minerStaking,
-            FoundationAccount foundation
-        ) = getFixtureData();
-
-        HackerAccountDistributeReEntry hacker = new HackerAccountDistributeReEntry();
-        hacker.setToken(token);
-        admin.setFoundation(address(hacker));
-        // assert balances
-        assertEq(address(madStaking).balance, 0);
-        assertEq(address(minerStaking).balance, 0);
-        assertEq(address(foundation).balance, 0);
-
-        // mint and transfer some tokens to the accounts
-        uint256 madBytes = token.mint{value: 400 ether}(0);
-        assertEq(madBytes, 39894_868089775762639314);
-
-        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
-    }
-
-    function testBurn() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount user = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(user).balance, 0 ether);
-        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(token.balanceOf(address(user)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        uint256 ethReceived = user.burn(madBytes - 100*ONE_MB);
-        assertEq(ethReceived, 9_749391845405398553);
-        assertEq(address(user).balance, ethReceived);
-        assertEq(token.totalSupply(), 100*ONE_MB);
-        assertEq(token.balanceOf(address(user)), 100*ONE_MB);
-        assertEq(address(token).balance, 40 ether - ethReceived);
-        assertEq(token.getPoolBalance(), 10 ether - ethReceived);
-        ethReceived = user.burn(100*ONE_MB);
-        assertEq(ethReceived, 10 ether - 9_749391845405398553);
-        assertEq(address(user).balance, 10 ether);
-        assertEq(address(token).balance, 30 ether);
-        assertEq(token.balanceOf(address(user)), 0);
-        assertEq(token.totalSupply(), 0);
         assertEq(token.getPoolBalance(), 0);
-        token.distribute();
-        assertEq(address(token).balance, 0);
+        EOA_SingleDeposit user = new EOA_SingleDeposit{value: 10 ether}(token);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+
+        assertEq(token.balanceOf(address(user)), user.madBytes());
+        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
+        assertEq(token.getDeposit(1), 100 * ONE_MB);
+        (address depositOwner, ) = token.getDepositOwner(1);
+        assertEq(depositOwner, address(user));
     }
 
-    function testBurnBillionsOfMadBytes() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount user = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(user).balance, 0 ether);
-        // Investing trillions of US dollars in ethereum
-        uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(this), 0);
-        assertEq(madBytes, 17501004975246203818081563855);
-        assertEq(token.totalSupply(), madBytes);
+    function testDoubleDeposit() public {
+        (MadByte token,,,,) = getFixtureData();
+        assertEq(token.getPoolBalance(), 0);
+        EOA_DoubleDeposit user = new EOA_DoubleDeposit{value: 10 ether}(token);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+
+        // first deposit
+        assertEq(token.balanceOf(address(user)), user.madBytes());
+        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
+        assertEq(token.getDeposit(1), 100 * ONE_MB);
+        (address depositOwner, ) = token.getDepositOwner(1);
+        assertEq(depositOwner, address(user));
+
+        // second deposit
+        assertEq(token.balanceOf(address(user)), user.madBytes());
+        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
+        assertEq(token.getDeposit(2), 199 * ONE_MB);
+        (address depositOwner2, ) = token.getDepositOwner(2);
+        assertEq(depositOwner2, address(user));
+    }
+
+    function testDepositTo() public {
+        (MadByte token,,,,) = getFixtureData();
+        address user = address(0xd39f14dCd02B9fC8A11bd95604D3E3E12Fd938EE);
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        emit log_named_uint("EOA MadBytes minted", madBytes);
+        emit log_named_address("EOA Msg sender", msg.sender);
         assertEq(token.balanceOf(address(this)), madBytes);
-        assertEq(address(token).balance, 70_000_000_000 ether);
-        assertEq(token.getPoolBalance(), 17500000000000000000000000000);
-        uint256 ethReceived = token.burnTo(address(user), madBytes, 0);
+
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        // first deposit
+        uint256 depositID = token.depositTo(user, 100 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 1);
+        assertEq(token.balanceOf(user), 0);
+        assertEq(token.balanceOf(address(this)), madBytes - (100 * ONE_MB));
+        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
+        assertEq(token.getDeposit(1), 100 * ONE_MB);
+        (address depositOwner, ) = token.getDepositOwner(1);
+        assertEq(depositOwner, user);
+
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        // second deposit
+        depositID = token.depositTo(user, 199 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 2);
+        assertEq(token.balanceOf(user), 0);
+        assertEq(token.balanceOf(address(this)), madBytes - (299 * ONE_MB));
+        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
+        assertEq(token.getDeposit(2), 199 * ONE_MB);
+        (address depositOwner2, ) = token.getDepositOwner(2);
+        assertEq(depositOwner2, user);
     }
 
-    function testFail_BurnMoreThanPossible() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount user = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(user).balance, 0 ether);
-        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(token.balanceOf(address(user)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        // trying to burn more than the max supply
-        user.burn(madBytes + 100*ONE_MB);
-    }
-
-    function testFail_BurnZeroMBTokens() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount user = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(user).balance, 0 ether);
-        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
-        assertEq(token.balanceOf(address(user)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        user.burn(0);
-    }
-
-    function testBurnTo() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount userTo = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(userTo).balance, 0 ether);
-        uint256 madBytes = token.mint{value: 40 ether}(0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
+    function testDepositToBN() public {
+        (MadByte token,,,,) = getFixtureData();
+        MadByte.BNAddress memory user = MadByte.BNAddress(bytes32("0x1"), bytes32("0x2"), bytes32("0x3"), bytes32("0x4"));
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        emit log_named_uint("EOA MadBytes minted", madBytes);
+        emit log_named_address("EOA Msg sender", msg.sender);
         assertEq(token.balanceOf(address(this)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        uint256 ethReceived = token.burnTo(address(userTo), madBytes - 100*ONE_MB, 0);
-        assertEq(ethReceived, 9_749391845405398553);
-        assertEq(address(userTo).balance, ethReceived);
-        assertEq(token.totalSupply(), 100*ONE_MB);
-        assertEq(token.balanceOf(address(this)), 100*ONE_MB);
-        assertEq(address(token).balance, 40 ether - ethReceived);
-        assertEq(token.getPoolBalance(), 10 ether - ethReceived);
+
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        // first deposit
+        uint256 depositID = token.depositToBN(user.to0, user.to1, user.to2, user.to3, 100 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 1);
+        assertEq(token.balanceOf(address(this)), madBytes - (100 * ONE_MB));
+        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
+        assertEq(token.getDeposit(1), 100 * ONE_MB);
+        (, MadByte.BNAddress memory depositOwner) = token.getDepositOwner(1);
+        assertEqBNAddress(depositOwner, user);
+
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        // second deposit
+        depositID = token.depositToBN(user.to0, user.to1, user.to2, user.to3, 199 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 2);
+        assertEq(token.balanceOf(address(this)), madBytes - (299 * ONE_MB));
+        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
+        assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
+        assertEq(token.getDeposit(2), 199 * ONE_MB);
+        (, MadByte.BNAddress memory depositOwner2) = token.getDepositOwner(2);
+        assertEqBNAddress(depositOwner2, user);
     }
 
-    function testFail_BurnToMoreThanPossible() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount userTo = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(userTo).balance, 0 ether);
-        uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
+    function testDepositZeroMadBytes() public {
+        (MadByte token,,,,) = getFixtureData();
+        address user = address(0xd39f14dCd02B9fC8A11bd95604D3E3E12Fd938EE);
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        emit log_named_uint("EOA MadBytes minted", madBytes);
+        emit log_named_address("EOA Msg sender", msg.sender);
         assertEq(token.balanceOf(address(this)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        // trying to burn more than the max supply
-        token.burnTo(address(userTo), madBytes + 100*ONE_MB, 0);
-    }
 
-    function testFail_BurnToZeroMBTokens() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount userTo = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(userTo).balance, 0 ether);
-        uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        // first deposit
+        uint256 depositID = token.depositTo(user, 0);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 1);
+        assertEq(token.balanceOf(user), 0);
         assertEq(token.balanceOf(address(this)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        token.burnTo(address(userTo), 0, 0);
+        assertEq(token.balanceOf(address(token)), 0);
+        assertEq(token.getTotalMadBytesDeposited(), 0);
+        assertEq(token.getDeposit(1), 0);
+        (address depositOwner, ) = token.getDepositOwner(1);
+        assertEq(depositOwner, user);
     }
 
-    function testFail_BurnToZeroAddress() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount userTo = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(userTo).balance, 0 ether);
-        uint256 madBytes = token.mint{value: 40 ether}(0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
+    function testVirtualMintDeposit() public {
+        (MadByte token, AdminAccount admin,,,) = getFixtureData();
+        address user = address(0xd39f14dCd02B9fC8A11bd95604D3E3E12Fd938EE);
+        uint256 madBytes = token.mint{value: 10 ether}(0);
         assertEq(token.balanceOf(address(this)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        token.burnTo(address(0), madBytes, 0);
-    }
 
-    function testFail_BurnWithBigMinEthAmount() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount userTo = newUserAccount(token);
-        assertEq(token.totalSupply(), 0);
-        assertEq(address(token).balance, 0 ether);
-        assertEq(address(userTo).balance, 0 ether);
-        uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        // first deposit
+        uint256 depositID = admin.virtualMintDeposit(user, 100 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 1);
+        assertEq(token.balanceOf(user), 0);
         assertEq(token.balanceOf(address(this)), madBytes);
-        assertEq(address(token).balance, 40 ether);
-        assertEq(token.getPoolBalance(), 10 ether);
-        // trying to burn more than the max supply
-        token.burnTo(address(userTo), 100*ONE_MB, 40 ether);
+        assertEq(token.balanceOf(address(token)), 0);
+        assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
+        assertEq(token.getDeposit(1), 100 * ONE_MB);
+        (address depositOwner, ) = token.getDepositOwner(1);
+        assertEq(depositOwner, user);
+
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        // second deposit
+        depositID = admin.virtualMintDeposit(user, 199 * ONE_MB);
+        assertEq(token.getPoolBalance(), 2_500000000000000000);
+        assertEq(depositID, 2);
+        assertEq(token.balanceOf(user), 0);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(token.balanceOf(address(token)), 0);
+        assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
+        assertEq(token.getDeposit(2), 199 * ONE_MB);
+        (address depositOwner2, ) = token.getDepositOwner(2);
+        assertEq(depositOwner2, user);
     }
 
-    function testBurnReEntrant() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        HackerAccountBurnReEntry hacker = new HackerAccountBurnReEntry();
-        hacker.setToken(token);
-        // assert balances
-        assertEq(token.totalSupply(), 0);
+    function testMintDeposit() public {
+        (MadByte token,,,,) = getFixtureData();
+        address user = address(0xd39f14dCd02B9fC8A11bd95604D3E3E12Fd938EE);
+        assertEq(token.getPoolBalance(), 0);
+        uint256 depositID = token.mintDeposit{value: 10 ether}(user, 0);
+        assertEq(token.getPoolBalance(), 0);
+        assertEq(depositID, 1);
+        assertEq(token.balanceOf(address(user)), 0);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(token.getTotalMadBytesDeposited(), token.getDeposit(1));
+        (address depositOwner, ) = token.getDepositOwner(depositID);
+        assertEq(depositOwner, user);
 
-        // mint some tokens to the accounts
-        uint256 madBytesHacker = token.mintTo{value: 40 ether}(address(hacker), 0);
-        assertEq(madBytesHacker, 3990_217121585928137263);
-        assertEq(token.balanceOf(address(hacker)), madBytesHacker);
-        // Transferring the excess to get only 100 MD on the hacker account to make checks easier
-        hacker.transfer(address(this), madBytesHacker - 100*ONE_MB);
-        assertEq(token.balanceOf(address(hacker)), 100*ONE_MB);
-        emit log_named_uint("MadNet balance hacker:", token.balanceOf(address(hacker)));
+        assertEq(token.getPoolBalance(), 0);
+        uint256 depositID2 = token.mintDeposit{value: 10 ether}(user, 0);
+        assertEq(token.getPoolBalance(), 0);
+        assertEq(depositID2, 2);
+        assertEq(token.balanceOf(address(user)), 0);
+        assertEq(token.balanceOf(address(this)), 0);
+        assertEq(token.getTotalMadBytesDeposited(), token.getDeposit(1)+token.getDeposit(2));
+        (address depositOwner2, ) = token.getDepositOwner(depositID2);
 
-        assertEq(address(token).balance, 40 ether);
-        assertEq(address(hacker).balance, 0 ether);
+        assertEq(depositOwner2, user);
+        assertEq(token.getDeposit(2), token.getDeposit(1));
+        emit log_named_uint("Amount deposit 1", token.getDeposit(1));
+        emit log_named_uint("Amount deposit 2", token.getDeposit(2));
 
-        // burning with reentrancy 5 times
-        uint256 ethReceivedHacker = hacker.burn(20*ONE_MB);
-
-        assertEq(token.balanceOf(address(hacker)), 0*ONE_MB);
-        assertEq(address(hacker).balance, 250617721342188290);
-        emit log_named_uint("Real Hacker Balance ETH", address(hacker).balance);
-
-        // If this check fails we had a reentrancy issue
-        assertEq(address(token).balance, 39_749382278657811710);
-
-        // testing a honest user
-        ( MadByte token2, , , , ) = getFixtureData();
-        assertEq(token2.totalSupply(), 0);
-        UserAccount honestUser = newUserAccount(token2);
-        uint256 madBytes = token2.mintTo{value: 40 ether}(address(honestUser), 0);
-        assertEq(madBytes, 3990_217121585928137263);
-        assertEq(token2.balanceOf(address(honestUser)), madBytes);
-        // Transferring the excess to get only 100 MD on the hacker account to make checks easier
-        honestUser.transfer(address(this), madBytes - 100*ONE_MB);
-        assertEq(address(token2).balance, 40 ether);
-        assertEq(address(honestUser).balance, 0 ether);
-        emit log_named_uint("Initial MadNet balance honestUser:", token2.balanceOf(address(honestUser)));
-
-        uint256 totalBurnt = 0;
-        for (uint256 i=0; i<5; i++){
-            totalBurnt += honestUser.burn(20*ONE_MB);
-        }
-        // the honest user must have the same balance as the hacker
-        assertEq(token2.balanceOf(address(honestUser)), 0);
-        assertEq(address(honestUser).balance, address(hacker).balance);
-        assertEq(address(token2).balance, address(token).balance);
-        emit log_named_uint("Honest Balance ETH", address(honestUser).balance);
-    }
-
-    function testMarketSpreadWithMintAndBurn() public {
-        ( MadByte token, , , , ) = getFixtureData();
-
-        UserAccount user = newUserAccount(token);
-        uint256 supply = token.totalSupply();
-        assertEq(supply, 0);
-
-        // mint
-        uint256 mintedTokens = user.mint{value: 40 ether}(0);
-        assertEq(mintedTokens, token.balanceOf(address(user)));
-
-        // burn
-        uint256 receivedEther = user.burn(mintedTokens);
-        assertEq(receivedEther, 10 ether);
-    }
-
-    function test_MintAndBurnALotThanBurnEverything(uint96 amountETH) public {
-        if (amountETH == 0) {
-            return;
-        }
-        uint256 maxIt = 10;
-        if (amountETH <= maxIt) {
-            amountETH = amountETH+uint96(maxIt)**2+1;
-        }
-        TokenPure token = new TokenPure();
-        uint256 initialMB = token.mint(amountETH);
-        emit log_named_uint("Initial supply:    ", token.totalSupply());
-        uint256 madBytes = token.mint(amountETH);
-        emit log_named_uint("Mb generated 2:   ", madBytes);
-        emit log_named_uint("Initial supply2:   ", token.totalSupply());
-
-        uint256 cumulativeMBBurned = 0;
-        uint256 cumulativeMBMinted = 0;
-        uint256 cumulativeETHBurned = 0;
-        uint256 cumulativeETHMinted = 0;
-        uint256 amountBurned = madBytes/maxIt;
-        uint256 amountMinted = amountETH/10000;
-        if (amountMinted == 0) {
-            amountMinted=1;
-        }
-        for (uint256 i=0; i<maxIt; i++) {
-            amountBurned = _min(amountBurned, token.totalSupply());
-            cumulativeETHBurned += token.burn(amountBurned);
-            cumulativeMBBurned += amountBurned;
-            cumulativeMBMinted += token.mint(amountMinted);
-            cumulativeETHMinted += amountMinted;
-        }
-        int256 burnedMBDiff = int256(cumulativeMBBurned)-int256(cumulativeMBMinted);
-        if (burnedMBDiff < 0) {
-            burnedMBDiff *= -1;
-        }
-        uint256 burnedETH = token.burn(token.totalSupply());
-
-        emit log("=======================================================");
-        emit log_named_uint("Token Balance:    ", token.totalSupply());
-        emit log_named_uint("amountMinted ETH   ", amountMinted);
-        emit log_named_uint("amountBurned       ", amountBurned);
-        emit log_named_uint("cumulativeMBBurned ", cumulativeMBBurned);
-        emit log_named_uint("cumulativeMBMinted ", cumulativeMBMinted);
-        emit log_named_uint("cumulativeETHBurned", cumulativeETHBurned);
-        emit log_named_uint("cumulativeETHMinted", cumulativeETHMinted);
-        emit log_named_int("Diff MB after loop ", burnedMBDiff);
-        emit log_named_uint("Final ETH burned   ", burnedETH);
-        emit log_named_uint("Token1 Balance:    ", token.poolBalance());
-        emit log_named_uint("Token1 supply:     ", token.totalSupply());
-        assertTrue(token.poolBalance() >= 0);
-        assertEq(token.totalSupply(), 0);
-    }
-
-    function test_ConversionMBToEthAndEthMBFunctions(uint96 amountEth) public {
-        ( MadByte token, , , , ) = getFixtureData();
-
-        if (amountEth == 0) {
-            return;
-        }
-        uint256 poolBalance = amountEth;
-        uint256 totalSupply = token.EthtoMB(0, amountEth);
-        uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
-        uint256 totalSupplyAfter = _fx(poolBalanceAfter);
-        uint256 mb = totalSupply - totalSupplyAfter;
-        uint256 returnedEth = token.MBtoEth(poolBalance, totalSupply, mb);
-        emit log_named_uint("Diff:", poolBalance - returnedEth);
-        assertTrue(poolBalance - returnedEth == poolBalanceAfter);
-    }
-
-    function test_ConversionMBToEthAndEthMBToken(uint96 amountEth) public {
-        TokenPure token = new TokenPure();
-        if (amountEth == 0) {
-            return;
-        }
-        uint256 totalSupply = token.mint(amountEth);
-        uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
-        uint256 totalSupplyAfter = _fx(poolBalanceAfter);
-        uint256 mb = totalSupply - totalSupplyAfter;
-        uint256 poolBalanceBeforeBurn = token.poolBalance();
-        uint256 returnedEth = token.burn(mb);
-        emit log_named_uint("Tt supply after", totalSupplyAfter);
-        emit log_named_uint("MB burned      ", mb);
-        emit log_named_uint("Pool balance   ", poolBalanceBeforeBurn);
-        emit log_named_uint("Pool After     ", poolBalanceAfter);
-        emit log_named_uint("returnedEth    ", returnedEth);
-        emit log_named_uint("Diff           ", poolBalanceBeforeBurn - returnedEth);
-        emit log_named_uint("ExpectedDiff   ", poolBalanceAfter);
-        emit log_named_int("Delta          ", int256(poolBalanceAfter) - int256(poolBalanceBeforeBurn - returnedEth));
-        assertTrue(poolBalanceBeforeBurn - returnedEth == poolBalanceAfter);
-    }
-
-    function testInvariantHold() public {
-        /*
-        tests if the invariant holds with mint and burn:
-        ethIn / burn(mint(ethIn)) >= marketSpread;
-        */
-
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount user = newUserAccount(token);
-        UserAccount user2 = newUserAccount(token);
-
-        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-        uint256 ethReceived = user.burn(madBytes);
-
-        assertTrue(40 ether / ethReceived >= 4);
-
-        madBytes = token.mintTo{value: 40 ether}(address(user2), 0);
-        ethReceived = user2.burn(madBytes);
-
-        assertTrue(40 ether / ethReceived >= 4);
-
-        madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-        uint256 madBytes2 = token.mintTo{value: 40 ether}(address(user2), 0);
-        uint256 ethReceived2 = user2.burn(madBytes2);
-        ethReceived = user.burn(madBytes);
-
-        emit log_named_uint("inv1.1:", 40 ether / ethReceived);
-        emit log_named_uint("inv1.2:", 40 ether / ethReceived2);
-
-        assertTrue(40 ether / ethReceived >= 4);
-        assertTrue(40 ether / ethReceived2 >= 4);
-
-        // amounts that are not multiple of 4
-        madBytes = token.mintTo{value: 53 ether}(address(user), 0);
-        madBytes2 = token.mintTo{value: 53 ether}(address(user2), 0);
-        ethReceived2 = user2.burn(madBytes2);
-        ethReceived = user.burn(madBytes);
-
-        emit log_named_uint("inv1.1:", 53 ether / ethReceived);
-        emit log_named_uint("inv1.2:", 53 ether / ethReceived2);
-
-        assertTrue(53 ether / ethReceived >= 4);
-        assertTrue(53 ether / ethReceived2 >= 4);
-    }
-
-    function testInvariantHold2() public {
-        /*
-        tests if the invariant holds with mint and burn:
-        ethIn / burn(mint(ethIn)) >= marketSpread;
-        */
-
-        ( MadByte token, , , , ) = getFixtureData();
-        UserAccount user = newUserAccount(token);
-        UserAccount user2 = newUserAccount(token);
-
-        uint256 madBytes = token.mintTo{value: 4*2000 ether}(address(user), 0);
-        uint256 ethReceived = user.burn(madBytes);
-
-        emit log_named_uint("inv3:", 2000 ether / ethReceived);
-        assertTrue(4*2000 ether / ethReceived >= 4);
+        // testing if we are getting the same amount of MB from the normal mint
+        uint256 madBytes = token.mint{value: 10 ether}(0);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(token.getDeposit(1), madBytes);
 
     }
+
+
 }

--- a/src/MadByte.t.sol
+++ b/src/MadByte.t.sol
@@ -1059,38 +1059,6 @@ contract MadByteTest is DSTest, Sigmoid {
         token.virtualMintDeposit(address(0x0), 100);
     }
 
-    function testMakeDepositTo() public {
-        ( MadByte token, , , , ) = getFixtureData();
-        address user = 0x00a329c0648769A73afAc7F9381E08FB43dBEA72;
-        uint256 madBytes = token.mint{value: 10 ether}(0);
-        emit log_named_uint("MadBytes minted", madBytes);
-        assertEq(token.balanceOf(address(this)), madBytes);
-
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
-        uint256 depositID = token.depositTo(user, 100 * ONE_MB);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
-        assertEq(depositID, 1);
-        assertEq(token.balanceOf(address(this)), madBytes - 100 * ONE_MB);
-        assertEq(token.balanceOf(user), 0);
-        assertEq(token.balanceOf(address(token)), 100 * ONE_MB);
-        assertEq(token.getTotalMadBytesDeposited(), 100 * ONE_MB);
-        assertEq(token.getDeposit(depositID), 100 * ONE_MB);
-        (address depositOwner, ) = token.getDepositOwner(depositID);
-        assertEq(depositOwner, user);
-
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
-        uint256 depositID2 = token.depositTo(user, 199 * ONE_MB);
-        assertEq(token.getPoolBalance(), 2_500000000000000000);
-        assertEq(depositID2, 2);
-        assertEq(token.balanceOf(address(this)), madBytes - 299 * ONE_MB);
-        assertEq(token.balanceOf(user), 0);
-        assertEq(token.balanceOf(address(token)), 299 * ONE_MB);
-        assertEq(token.getTotalMadBytesDeposited(), 299 * ONE_MB);
-        assertEq(token.getDeposit(depositID2), 199 * ONE_MB);
-        (address depositOwner2, ) = token.getDepositOwner(depositID2);
-        assertEq(depositOwner2, user);
-    }
-
     function testSingleDeposit() public {
         (MadByte token,,,,) = getFixtureData();
         assertEq(token.getPoolBalance(), 0);

--- a/src/MadByte.t.sol
+++ b/src/MadByte.t.sol
@@ -267,748 +267,748 @@ contract MadByteTest is DSTest, Sigmoid {
 
     // test functions
 
-    // function testFail_noAdminSetMinerStaking() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     token.setMinerStaking(address(0x0));
-    // }
-
-    // function testFail_noAdminSetMadStaking() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     token.setMadStaking(address(0x0));
-    // }
-
-    // function testFail_noAdminSetFoundation() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     token.setFoundation(address(0x0));
-    // }
-
-    // function testFail_noAdminSetMinerSplit() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     token.setMinerSplit(100);
-    // }
-
-    // function testAdminSetters() public {
-    //     (,AdminAccount admin,,,) = getFixtureData();
-
-    //     admin.setMinerStaking(address(0x0));
-    //     admin.setMadStaking(address(0x0));
-    //     admin.setFoundation(address(0x0));
-    //     admin.setMinerSplit(100); // 100 = 10%, 1000 = 100%
-    // }
-
-    // function testFail_SettingMinerSplitGreaterThanMadUnitOne() public {
-    //     (,AdminAccount admin,,,) = getFixtureData();
-    //     admin.setMinerSplit(1000);
-    // }
-
-    // function testMint() public {
-    //     (MadByte token,,,,) = getFixtureData();
-
-    //     uint256 madBytes = token.mint{value: 4 ether}(0);
-    //     assertEq(madBytes, 399028731704364116575);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(address(token).balance, 4 ether);
-    //     assertEq(token.getPoolBalance(), 1 ether);
-
-    //     uint256 madBytes2 = token.mint{value: 4 ether}(0);
-    //     assertEq(madBytes2, 399027176702820751481);
-    //     assertEq(token.balanceOf(address(this)), madBytes2 + madBytes);
-    //     assertEq(token.totalSupply(), madBytes2 + madBytes);
-    //     assertEq(address(token).balance, 8 ether);
-    //     assertEq(token.getPoolBalance(), 2 ether);
-    // }
-
-    // function testMintExpectedBondingCurvePoints() public {
-    //     (MadByte token1,,,,) = getFixtureData();
-    //     (MadByte token2,,,,) = getFixtureData();
-    //     (MadByte token3,,,,) = getFixtureData();
-
-    //     uint256 madBytes = token1.mint{value: 10_000 ether}(0);
-    //     assertEq(madBytes, 936764568799449143863271);
-    //     assertEq(token1.totalSupply(), madBytes);
-    //     assertEq(address(token1).balance, 10_000 ether);
-    //     assertEq(token1.getPoolBalance(), 2_500 ether);
-
-    //     // at 20k ether we have a nice rounding value for madbytes generated
-    //     madBytes = token1.mint{value: 10_000 ether}(0);
-    //     assertEq(madBytes, 1005000000000000000000000 - 936764568799449143863271);
-    //     assertEq(token1.totalSupply(), 1005000000000000000000000);
-    //     assertEq(address(token1).balance, 20_000 ether);
-    //     assertEq(token1.getPoolBalance(), 5_000 ether);
-
-    //     // the only nice value when minting happens when we mint 20k ether
-    //     madBytes = token2.mint{value: 20_000 ether}(0);
-    //     assertEq(madBytes, 1005000000000000000000000);
-    //     assertEq(token2.totalSupply(), madBytes);
-    //     assertEq(address(token2).balance, 20_000 ether);
-    //     assertEq(token2.getPoolBalance(), 5_000 ether);
-
-    //     madBytes = token3.mint{value: 25_000 ether}(0);
-    //     assertEq(madBytes, 1007899288252135716968558);
-    //     assertEq(token3.totalSupply(), madBytes);
-    //     assertEq(address(token3).balance, 25_000 ether);
-    //     assertEq(token3.getPoolBalance(), 6_250 ether);
-
-    // }
-
-    // function testMintWithBillionsOfEthereum() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     // Investing trillions of US dollars in ethereum
-    //     uint256 madBytes = token.mint{value: 70_000_000_000 ether}(0);
-    //     assertEq(madBytes, 17501004975246203818081563855);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(this)), madBytes);
-    //     assertEq(address(token).balance, 70_000_000_000 ether);
-    //     assertEq(token.getPoolBalance(), 17500000000000000000000000000);
-    // }
-
-    // function testMintTo() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     UserAccount acct1 = newUserAccount(token);
-    //     UserAccount acct2 = newUserAccount(token);
-    //     uint256 madBytes = token.mintTo{value: 4 ether}(address(acct1), 0);
-    //     assertEq(madBytes, 399028731704364116575);
-    //     assertEq(token.balanceOf(address(acct1)), 399028731704364116575);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(address(token).balance, 4 ether);
-    //     assertEq(token.getPoolBalance(), 1 ether);
-
-    //     uint256 madBytes2 = token.mintTo{value: 4 ether}(address(acct2), 0);
-    //     assertEq(madBytes2, 399027176702820751481);
-    //     assertEq(token.balanceOf(address(acct2)), 399027176702820751481);
-    //     assertEq(token.totalSupply(), madBytes + madBytes2);
-    //     assertEq(address(token).balance, 8 ether);
-    //     assertEq(token.getPoolBalance(), 2 ether);
-    // }
-
-    // function testMintToWithBillionsOfEthereum() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount user = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(user).balance, 0 ether);
-    //     // Investing trillions of US dollars in ethereum
-    //     uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(user), 0);
-    //     assertEq(madBytes, 17501004975246203818081563855);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(user)), madBytes);
-    //     assertEq(address(token).balance, 70_000_000_000 ether);
-    //     assertEq(token.getPoolBalance(), 17500000000000000000000000000);
-    // }
-
-    // function testFail_MintToZeroAddress() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     UserAccount acct1 = newUserAccount(token);
-    //     UserAccount acct2 = newUserAccount(token);
-    //     token.mintTo{value: 4 ether}(address(0), 0);
-    // }
-
-    // function testFail_MintToBigMinMBQuantity() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     UserAccount acct1 = newUserAccount(token);
-    //     UserAccount acct2 = newUserAccount(token);
-    //     token.mintTo{value: 4 ether}(address(acct1), 900*ONE_MB);
-    // }
-
-    // function testTransfer() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     UserAccount acct1 = newUserAccount(token);
-    //     UserAccount acct2 = newUserAccount(token);
-
-    //     // mint and transfer some tokens to the accounts
-    //     uint256 madBytes = token.mint{value: 4 ether}(0);
-    //     assertEq(madBytes, 399_028731704364116575);
-    //     token.transfer(address(acct1), 2*ONE_MB);
-
-    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
-    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(initialBalance1, 2*ONE_MB);
-    //     assertEq(initialBalance2, 0);
-
-    //     acct1.transfer(address(acct2), ONE_MB);
-
-    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
-    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
-    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-    //     assertEq(finalBalance1, ONE_MB);
-    //     assertEq(finalBalance2, ONE_MB);
-    // }
-
-    // function testTransferFrom() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     UserAccount acct1 = newUserAccount(token);
-    //     UserAccount acct2 = newUserAccount(token);
-
-    //     // mint and transfer some tokens to the accounts
-    //     uint256 madBytes = token.mint{value: 4 ether}(0);
-    //     assertEq(madBytes, 399_028731704364116575);
-    //     token.transfer(address(acct1), 2*ONE_MB);
-
-    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
-    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(initialBalance1, 2*ONE_MB);
-    //     assertEq(initialBalance2, 0);
-
-    //     acct1.approve(address(this), ONE_MB);
-
-    //     token.transferFrom(address(acct1), address(acct2), ONE_MB);
-
-    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
-    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
-    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-    //     assertEq(finalBalance1, ONE_MB);
-    //     assertEq(finalBalance2, ONE_MB);
-    // }
-
-    // function testFail_TransferFromWithoutAllowance() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     UserAccount acct1 = newUserAccount(token);
-    //     UserAccount acct2 = newUserAccount(token);
-
-    //     // mint and transfer some tokens to the accounts
-    //     uint256 madBytes = token.mint{value: 4 ether}(0);
-    //     assertEq(madBytes, 399_028731704364116575);
-    //     token.transfer(address(acct1), 2*ONE_MB);
-
-    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
-    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(initialBalance1, 2*ONE_MB);
-    //     assertEq(initialBalance2, 0);
-
-    //     token.transferFrom(address(acct1), address(acct2), ONE_MB);
-
-    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
-    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
-    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-    //     assertEq(finalBalance1, ONE_MB);
-    //     assertEq(finalBalance2, ONE_MB);
-    // }
-
-    // function testFail_TransferMoreThanAllowance() public {
-    //     (MadByte token,,,,) = getFixtureData();
-    //     UserAccount acct1 = newUserAccount(token);
-    //     UserAccount acct2 = newUserAccount(token);
-
-    //     // mint and transfer some tokens to the accounts
-    //     uint256 madBytes = token.mint{value: 4 ether}(0);
-    //     assertEq(madBytes, 399_028731704364116575);
-    //     token.transfer(address(acct1), 2*ONE_MB);
-
-    //     uint256 initialBalance1 = token.balanceOf(address(acct1));
-    //     uint256 initialBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(initialBalance1, 2*ONE_MB);
-    //     assertEq(initialBalance2, 0);
-
-    //     acct1.approve(address(this), ONE_MB/2);
-    //     token.transferFrom(address(acct1), address(acct2), ONE_MB);
-
-    //     uint256 finalBalance1 = token.balanceOf(address(acct1));
-    //     uint256 finalBalance2 = token.balanceOf(address(acct2));
-
-    //     assertEq(finalBalance1, initialBalance1-ONE_MB);
-    //     assertEq(finalBalance2, initialBalance2+ONE_MB);
-
-    //     assertEq(finalBalance1, ONE_MB);
-    //     assertEq(finalBalance2, ONE_MB);
-    // }
-
-    // function testDistribute() public {
-    //     (
-    //         MadByte token,
-    //         ,
-    //         MadStakingAccount madStaking,
-    //         MinerStakingAccount minerStaking,
-    //         FoundationAccount foundation
-    //     ) = getFixtureData();
-
-    //     // assert balances
-    //     assertEq(address(madStaking).balance, 0);
-    //     assertEq(address(minerStaking).balance, 0);
-    //     assertEq(address(foundation).balance, 0);
-
-    //     // mint and transfer some tokens to the accounts
-    //     uint256 madBytes = token.mint{value: 4 ether}(0);
-    //     assertEq(399_028731704364116575, madBytes);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(address(token).balance, 4 ether);
-    //     assertEq(token.getPoolBalance(), 1 ether);
-
-    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-
-    //     (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
-
-    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-
-    //     // assert balances
-    //     assertEq(stakingAmount, 1495500000000000000);
-    //     assertEq(minerAmount, 1495500000000000000);
-    //     assertEq(foundationAmount, 9000000000000000);
-
-    //     assertEq(address(madStaking).balance, 1495500000000000000);
-    //     assertEq(address(minerStaking).balance, 1495500000000000000);
-    //     assertEq(address(foundation).balance, 9000000000000000);
-    //     assertEq(address(token).balance, 1 ether);
-    //     assertEq(token.getPoolBalance(), 1 ether);
-    // }
-
-    // function testDistributeWithMoreEthereum() public {
-    //     (
-    //         MadByte token,
-    //         ,
-    //         MadStakingAccount madStaking,
-    //         MinerStakingAccount minerStaking,
-    //         FoundationAccount foundation
-    //     ) = getFixtureData();
-
-    //     // assert balances
-    //     assertEq(address(madStaking).balance, 0);
-    //     assertEq(address(minerStaking).balance, 0);
-    //     assertEq(address(foundation).balance, 0);
-    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-    //     // mint and transfer some tokens to the accounts
-    //     uint256 madBytes = token.mint{value: 400 ether}(0);
-    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-    //     assertEq(madBytes, 39894_868089775762639314);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(address(token).balance, 400 ether);
-    //     assertEq(token.getPoolBalance(), 100 ether);
-
-    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-    //     (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
-    //     assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
-
-    //     // assert balances
-    //     assertEq(stakingAmount, 149550000000000000000);
-    //     assertEq(minerAmount, 149550000000000000000);
-    //     assertEq(foundationAmount, 900000000000000000);
-
-    //     assertEq(address(madStaking).balance, 149550000000000000000);
-    //     assertEq(address(minerStaking).balance, 149550000000000000000);
-    //     assertEq(address(foundation).balance, 900000000000000000);
-    //     assertEq(address(token).balance, 100 ether);
-    //     assertEq(token.getPoolBalance(), 100 ether);
-    // }
-
-    // function testFail_DistributeReEntrant() public {
-    //     (
-    //         MadByte token,
-    //         AdminAccount admin,
-    //         MadStakingAccount madStaking,
-    //         MinerStakingAccount minerStaking,
-    //         FoundationAccount foundation
-    //     ) = getFixtureData();
-
-    //     HackerAccountDistributeReEntry hacker = new HackerAccountDistributeReEntry();
-    //     hacker.setToken(token);
-    //     admin.setFoundation(address(hacker));
-    //     // assert balances
-    //     assertEq(address(madStaking).balance, 0);
-    //     assertEq(address(minerStaking).balance, 0);
-    //     assertEq(address(foundation).balance, 0);
-
-    //     // mint and transfer some tokens to the accounts
-    //     uint256 madBytes = token.mint{value: 400 ether}(0);
-    //     assertEq(madBytes, 39894_868089775762639314);
-
-    //     (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
-    // }
-
-    // function testBurn() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount user = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(user).balance, 0 ether);
-    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(user)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     uint256 ethReceived = user.burn(madBytes - 100*ONE_MB);
-    //     assertEq(ethReceived, 9_749391845405398553);
-    //     assertEq(address(user).balance, ethReceived);
-    //     assertEq(token.totalSupply(), 100*ONE_MB);
-    //     assertEq(token.balanceOf(address(user)), 100*ONE_MB);
-    //     assertEq(address(token).balance, 40 ether - ethReceived);
-    //     assertEq(token.getPoolBalance(), 10 ether - ethReceived);
-    //     ethReceived = user.burn(100*ONE_MB);
-    //     assertEq(ethReceived, 10 ether - 9_749391845405398553);
-    //     assertEq(address(user).balance, 10 ether);
-    //     assertEq(address(token).balance, 30 ether);
-    //     assertEq(token.balanceOf(address(user)), 0);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(token.getPoolBalance(), 0);
-    //     token.distribute();
-    //     assertEq(address(token).balance, 0);
-    // }
-
-    // function testBurnBillionsOfMadBytes() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount user = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(user).balance, 0 ether);
-    //     // Investing trillions of US dollars in ethereum
-    //     uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(this), 0);
-    //     assertEq(madBytes, 17501004975246203818081563855);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(this)), madBytes);
-    //     assertEq(address(token).balance, 70_000_000_000 ether);
-    //     assertEq(token.getPoolBalance(), 17500000000000000000000000000);
-    //     uint256 ethReceived = token.burnTo(address(user), madBytes, 0);
-    // }
-
-    // function testFail_BurnMoreThanPossible() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount user = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(user).balance, 0 ether);
-    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(user)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     // trying to burn more than the max supply
-    //     user.burn(madBytes + 100*ONE_MB);
-    // }
-
-    // function testFail_BurnZeroMBTokens() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount user = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(user).balance, 0 ether);
-    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(user)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     user.burn(0);
-    // }
-
-    // function testBurnTo() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount userTo = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(userTo).balance, 0 ether);
-    //     uint256 madBytes = token.mint{value: 40 ether}(0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(this)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     uint256 ethReceived = token.burnTo(address(userTo), madBytes - 100*ONE_MB, 0);
-    //     assertEq(ethReceived, 9_749391845405398553);
-    //     assertEq(address(userTo).balance, ethReceived);
-    //     assertEq(token.totalSupply(), 100*ONE_MB);
-    //     assertEq(token.balanceOf(address(this)), 100*ONE_MB);
-    //     assertEq(address(token).balance, 40 ether - ethReceived);
-    //     assertEq(token.getPoolBalance(), 10 ether - ethReceived);
-    // }
-
-    // function testFail_BurnToMoreThanPossible() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount userTo = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(userTo).balance, 0 ether);
-    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(this)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     // trying to burn more than the max supply
-    //     token.burnTo(address(userTo), madBytes + 100*ONE_MB, 0);
-    // }
-
-    // function testFail_BurnToZeroMBTokens() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount userTo = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(userTo).balance, 0 ether);
-    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(this)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     token.burnTo(address(userTo), 0, 0);
-    // }
-
-    // function testFail_BurnToZeroAddress() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount userTo = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(userTo).balance, 0 ether);
-    //     uint256 madBytes = token.mint{value: 40 ether}(0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(this)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     token.burnTo(address(0), madBytes, 0);
-    // }
-
-    // function testFail_BurnWithBigMinEthAmount() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount userTo = newUserAccount(token);
-    //     assertEq(token.totalSupply(), 0);
-    //     assertEq(address(token).balance, 0 ether);
-    //     assertEq(address(userTo).balance, 0 ether);
-    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token.totalSupply(), madBytes);
-    //     assertEq(token.balanceOf(address(this)), madBytes);
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(token.getPoolBalance(), 10 ether);
-    //     // trying to burn more than the max supply
-    //     token.burnTo(address(userTo), 100*ONE_MB, 40 ether);
-    // }
-
-    // function testBurnReEntrant() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     HackerAccountBurnReEntry hacker = new HackerAccountBurnReEntry();
-    //     hacker.setToken(token);
-    //     // assert balances
-    //     assertEq(token.totalSupply(), 0);
-
-    //     // mint some tokens to the accounts
-    //     uint256 madBytesHacker = token.mintTo{value: 40 ether}(address(hacker), 0);
-    //     assertEq(madBytesHacker, 3990_217121585928137263);
-    //     assertEq(token.balanceOf(address(hacker)), madBytesHacker);
-    //     // Transferring the excess to get only 100 MD on the hacker account to make checks easier
-    //     hacker.transfer(address(this), madBytesHacker - 100*ONE_MB);
-    //     assertEq(token.balanceOf(address(hacker)), 100*ONE_MB);
-    //     emit log_named_uint("MadNet balance hacker:", token.balanceOf(address(hacker)));
-
-    //     assertEq(address(token).balance, 40 ether);
-    //     assertEq(address(hacker).balance, 0 ether);
-
-    //     // burning with reentrancy 5 times
-    //     uint256 ethReceivedHacker = hacker.burn(20*ONE_MB);
-
-    //     assertEq(token.balanceOf(address(hacker)), 0*ONE_MB);
-    //     assertEq(address(hacker).balance, 250617721342188290);
-    //     emit log_named_uint("Real Hacker Balance ETH", address(hacker).balance);
-
-    //     // If this check fails we had a reentrancy issue
-    //     assertEq(address(token).balance, 39_749382278657811710);
-
-    //     // testing a honest user
-    //     ( MadByte token2, , , , ) = getFixtureData();
-    //     assertEq(token2.totalSupply(), 0);
-    //     UserAccount honestUser = newUserAccount(token2);
-    //     uint256 madBytes = token2.mintTo{value: 40 ether}(address(honestUser), 0);
-    //     assertEq(madBytes, 3990_217121585928137263);
-    //     assertEq(token2.balanceOf(address(honestUser)), madBytes);
-    //     // Transferring the excess to get only 100 MD on the hacker account to make checks easier
-    //     honestUser.transfer(address(this), madBytes - 100*ONE_MB);
-    //     assertEq(address(token2).balance, 40 ether);
-    //     assertEq(address(honestUser).balance, 0 ether);
-    //     emit log_named_uint("Initial MadNet balance honestUser:", token2.balanceOf(address(honestUser)));
-
-    //     uint256 totalBurnt = 0;
-    //     for (uint256 i=0; i<5; i++){
-    //         totalBurnt += honestUser.burn(20*ONE_MB);
-    //     }
-    //     // the honest user must have the same balance as the hacker
-    //     assertEq(token2.balanceOf(address(honestUser)), 0);
-    //     assertEq(address(honestUser).balance, address(hacker).balance);
-    //     assertEq(address(token2).balance, address(token).balance);
-    //     emit log_named_uint("Honest Balance ETH", address(honestUser).balance);
-    // }
-
-    // function testMarketSpreadWithMintAndBurn() public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-
-    //     UserAccount user = newUserAccount(token);
-    //     uint256 supply = token.totalSupply();
-    //     assertEq(supply, 0);
-
-    //     // mint
-    //     uint256 mintedTokens = user.mint{value: 40 ether}(0);
-    //     assertEq(mintedTokens, token.balanceOf(address(user)));
-
-    //     // burn
-    //     uint256 receivedEther = user.burn(mintedTokens);
-    //     assertEq(receivedEther, 10 ether);
-    // }
-
-    // function test_MintAndBurnALotThanBurnEverything(uint96 amountETH) public {
-    //     if (amountETH == 0) {
-    //         return;
-    //     }
-    //     uint256 maxIt = 10;
-    //     if (amountETH <= maxIt) {
-    //         amountETH = amountETH+uint96(maxIt)**2+1;
-    //     }
-    //     TokenPure token = new TokenPure();
-    //     uint256 initialMB = token.mint(amountETH);
-    //     emit log_named_uint("Initial supply:    ", token.totalSupply());
-    //     uint256 madBytes = token.mint(amountETH);
-    //     emit log_named_uint("Mb generated 2:   ", madBytes);
-    //     emit log_named_uint("Initial supply2:   ", token.totalSupply());
-
-    //     uint256 cumulativeMBBurned = 0;
-    //     uint256 cumulativeMBMinted = 0;
-    //     uint256 cumulativeETHBurned = 0;
-    //     uint256 cumulativeETHMinted = 0;
-    //     uint256 amountBurned = madBytes/maxIt;
-    //     uint256 amountMinted = amountETH/10000;
-    //     if (amountMinted == 0) {
-    //         amountMinted=1;
-    //     }
-    //     for (uint256 i=0; i<maxIt; i++) {
-    //         amountBurned = _min(amountBurned, token.totalSupply());
-    //         cumulativeETHBurned += token.burn(amountBurned);
-    //         cumulativeMBBurned += amountBurned;
-    //         cumulativeMBMinted += token.mint(amountMinted);
-    //         cumulativeETHMinted += amountMinted;
-    //     }
-    //     int256 burnedMBDiff = int256(cumulativeMBBurned)-int256(cumulativeMBMinted);
-    //     if (burnedMBDiff < 0) {
-    //         burnedMBDiff *= -1;
-    //     }
-    //     uint256 burnedETH = token.burn(token.totalSupply());
-
-    //     emit log("=======================================================");
-    //     emit log_named_uint("Token Balance:    ", token.totalSupply());
-    //     emit log_named_uint("amountMinted ETH   ", amountMinted);
-    //     emit log_named_uint("amountBurned       ", amountBurned);
-    //     emit log_named_uint("cumulativeMBBurned ", cumulativeMBBurned);
-    //     emit log_named_uint("cumulativeMBMinted ", cumulativeMBMinted);
-    //     emit log_named_uint("cumulativeETHBurned", cumulativeETHBurned);
-    //     emit log_named_uint("cumulativeETHMinted", cumulativeETHMinted);
-    //     emit log_named_int("Diff MB after loop ", burnedMBDiff);
-    //     emit log_named_uint("Final ETH burned   ", burnedETH);
-    //     emit log_named_uint("Token1 Balance:    ", token.poolBalance());
-    //     emit log_named_uint("Token1 supply:     ", token.totalSupply());
-    //     assertTrue(token.poolBalance() >= 0);
-    //     assertEq(token.totalSupply(), 0);
-    // }
-
-    // function test_ConversionMBToEthAndEthMBFunctions(uint96 amountEth) public {
-    //     ( MadByte token, , , , ) = getFixtureData();
-
-    //     if (amountEth == 0) {
-    //         return;
-    //     }
-    //     uint256 poolBalance = amountEth;
-    //     uint256 totalSupply = token.EthtoMB(0, amountEth);
-    //     uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
-    //     uint256 totalSupplyAfter = _fx(poolBalanceAfter);
-    //     uint256 mb = totalSupply - totalSupplyAfter;
-    //     uint256 returnedEth = token.MBtoEth(poolBalance, totalSupply, mb);
-    //     emit log_named_uint("Diff:", poolBalance - returnedEth);
-    //     assertTrue(poolBalance - returnedEth == poolBalanceAfter);
-    // }
-
-    // function test_ConversionMBToEthAndEthMBToken(uint96 amountEth) public {
-    //     TokenPure token = new TokenPure();
-    //     if (amountEth == 0) {
-    //         return;
-    //     }
-    //     uint256 totalSupply = token.mint(amountEth);
-    //     uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
-    //     uint256 totalSupplyAfter = _fx(poolBalanceAfter);
-    //     uint256 mb = totalSupply - totalSupplyAfter;
-    //     uint256 poolBalanceBeforeBurn = token.poolBalance();
-    //     uint256 returnedEth = token.burn(mb);
-    //     emit log_named_uint("Tt supply after", totalSupplyAfter);
-    //     emit log_named_uint("MB burned      ", mb);
-    //     emit log_named_uint("Pool balance   ", poolBalanceBeforeBurn);
-    //     emit log_named_uint("Pool After     ", poolBalanceAfter);
-    //     emit log_named_uint("returnedEth    ", returnedEth);
-    //     emit log_named_uint("Diff           ", poolBalanceBeforeBurn - returnedEth);
-    //     emit log_named_uint("ExpectedDiff   ", poolBalanceAfter);
-    //     emit log_named_int("Delta          ", int256(poolBalanceAfter) - int256(poolBalanceBeforeBurn - returnedEth));
-    //     assertTrue(poolBalanceBeforeBurn - returnedEth == poolBalanceAfter);
-    // }
-
-    // function testInvariantHold() public {
-    //     /*
-    //     tests if the invariant holds with mint and burn:
-    //     ethIn / burn(mint(ethIn)) >= marketSpread;
-    //     */
-
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount user = newUserAccount(token);
-    //     UserAccount user2 = newUserAccount(token);
-
-    //     uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-    //     uint256 ethReceived = user.burn(madBytes);
-
-    //     assertTrue(40 ether / ethReceived >= 4);
-
-    //     madBytes = token.mintTo{value: 40 ether}(address(user2), 0);
-    //     ethReceived = user2.burn(madBytes);
-
-    //     assertTrue(40 ether / ethReceived >= 4);
-
-    //     madBytes = token.mintTo{value: 40 ether}(address(user), 0);
-    //     uint256 madBytes2 = token.mintTo{value: 40 ether}(address(user2), 0);
-    //     uint256 ethReceived2 = user2.burn(madBytes2);
-    //     ethReceived = user.burn(madBytes);
-
-    //     emit log_named_uint("inv1.1:", 40 ether / ethReceived);
-    //     emit log_named_uint("inv1.2:", 40 ether / ethReceived2);
-
-    //     assertTrue(40 ether / ethReceived >= 4);
-    //     assertTrue(40 ether / ethReceived2 >= 4);
-
-    //     // amounts that are not multiple of 4
-    //     madBytes = token.mintTo{value: 53 ether}(address(user), 0);
-    //     madBytes2 = token.mintTo{value: 53 ether}(address(user2), 0);
-    //     ethReceived2 = user2.burn(madBytes2);
-    //     ethReceived = user.burn(madBytes);
-
-    //     emit log_named_uint("inv1.1:", 53 ether / ethReceived);
-    //     emit log_named_uint("inv1.2:", 53 ether / ethReceived2);
-
-    //     assertTrue(53 ether / ethReceived >= 4);
-    //     assertTrue(53 ether / ethReceived2 >= 4);
-    // }
-
-    // function testInvariantHold2() public {
-    //     /*
-    //     tests if the invariant holds with mint and burn:
-    //     ethIn / burn(mint(ethIn)) >= marketSpread;
-    //     */
-
-    //     ( MadByte token, , , , ) = getFixtureData();
-    //     UserAccount user = newUserAccount(token);
-    //     UserAccount user2 = newUserAccount(token);
-
-    //     uint256 madBytes = token.mintTo{value: 4*2000 ether}(address(user), 0);
-    //     uint256 ethReceived = user.burn(madBytes);
-
-    //     emit log_named_uint("inv3:", 2000 ether / ethReceived);
-    //     assertTrue(4*2000 ether / ethReceived >= 4);
-
-    // }
+    function testFail_noAdminSetMinerStaking() public {
+        (MadByte token,,,,) = getFixtureData();
+        token.setMinerStaking(address(0x0));
+    }
+
+    function testFail_noAdminSetMadStaking() public {
+        (MadByte token,,,,) = getFixtureData();
+        token.setMadStaking(address(0x0));
+    }
+
+    function testFail_noAdminSetFoundation() public {
+        (MadByte token,,,,) = getFixtureData();
+        token.setFoundation(address(0x0));
+    }
+
+    function testFail_noAdminSetMinerSplit() public {
+        (MadByte token,,,,) = getFixtureData();
+        token.setMinerSplit(100);
+    }
+
+    function testAdminSetters() public {
+        (,AdminAccount admin,,,) = getFixtureData();
+
+        admin.setMinerStaking(address(0x0));
+        admin.setMadStaking(address(0x0));
+        admin.setFoundation(address(0x0));
+        admin.setMinerSplit(100); // 100 = 10%, 1000 = 100%
+    }
+
+    function testFail_SettingMinerSplitGreaterThanMadUnitOne() public {
+        (,AdminAccount admin,,,) = getFixtureData();
+        admin.setMinerSplit(1000);
+    }
+
+    function testMint() public {
+        (MadByte token,,,,) = getFixtureData();
+
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(madBytes, 399028731704364116575);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(address(token).balance, 4 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+
+        uint256 madBytes2 = token.mint{value: 4 ether}(0);
+        assertEq(madBytes2, 399027176702820751481);
+        assertEq(token.balanceOf(address(this)), madBytes2 + madBytes);
+        assertEq(token.totalSupply(), madBytes2 + madBytes);
+        assertEq(address(token).balance, 8 ether);
+        assertEq(token.getPoolBalance(), 2 ether);
+    }
+
+    function testMintExpectedBondingCurvePoints() public {
+        (MadByte token1,,,,) = getFixtureData();
+        (MadByte token2,,,,) = getFixtureData();
+        (MadByte token3,,,,) = getFixtureData();
+
+        uint256 madBytes = token1.mint{value: 10_000 ether}(0);
+        assertEq(madBytes, 936764568799449143863271);
+        assertEq(token1.totalSupply(), madBytes);
+        assertEq(address(token1).balance, 10_000 ether);
+        assertEq(token1.getPoolBalance(), 2_500 ether);
+
+        // at 20k ether we have a nice rounding value for madbytes generated
+        madBytes = token1.mint{value: 10_000 ether}(0);
+        assertEq(madBytes, 1005000000000000000000000 - 936764568799449143863271);
+        assertEq(token1.totalSupply(), 1005000000000000000000000);
+        assertEq(address(token1).balance, 20_000 ether);
+        assertEq(token1.getPoolBalance(), 5_000 ether);
+
+        // the only nice value when minting happens when we mint 20k ether
+        madBytes = token2.mint{value: 20_000 ether}(0);
+        assertEq(madBytes, 1005000000000000000000000);
+        assertEq(token2.totalSupply(), madBytes);
+        assertEq(address(token2).balance, 20_000 ether);
+        assertEq(token2.getPoolBalance(), 5_000 ether);
+
+        madBytes = token3.mint{value: 25_000 ether}(0);
+        assertEq(madBytes, 1007899288252135716968558);
+        assertEq(token3.totalSupply(), madBytes);
+        assertEq(address(token3).balance, 25_000 ether);
+        assertEq(token3.getPoolBalance(), 6_250 ether);
+
+    }
+
+    function testMintWithBillionsOfEthereum() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        // Investing trillions of US dollars in ethereum
+        uint256 madBytes = token.mint{value: 70_000_000_000 ether}(0);
+        assertEq(madBytes, 17501004975246203818081563855);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(address(token).balance, 70_000_000_000 ether);
+        assertEq(token.getPoolBalance(), 17500000000000000000000000000);
+    }
+
+    function testMintTo() public {
+        (MadByte token,,,,) = getFixtureData();
+        UserAccount acct1 = newUserAccount(token);
+        UserAccount acct2 = newUserAccount(token);
+        uint256 madBytes = token.mintTo{value: 4 ether}(address(acct1), 0);
+        assertEq(madBytes, 399028731704364116575);
+        assertEq(token.balanceOf(address(acct1)), 399028731704364116575);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(address(token).balance, 4 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+
+        uint256 madBytes2 = token.mintTo{value: 4 ether}(address(acct2), 0);
+        assertEq(madBytes2, 399027176702820751481);
+        assertEq(token.balanceOf(address(acct2)), 399027176702820751481);
+        assertEq(token.totalSupply(), madBytes + madBytes2);
+        assertEq(address(token).balance, 8 ether);
+        assertEq(token.getPoolBalance(), 2 ether);
+    }
+
+    function testMintToWithBillionsOfEthereum() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount user = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(user).balance, 0 ether);
+        // Investing trillions of US dollars in ethereum
+        uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(user), 0);
+        assertEq(madBytes, 17501004975246203818081563855);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(user)), madBytes);
+        assertEq(address(token).balance, 70_000_000_000 ether);
+        assertEq(token.getPoolBalance(), 17500000000000000000000000000);
+    }
+
+    function testFail_MintToZeroAddress() public {
+        (MadByte token,,,,) = getFixtureData();
+        UserAccount acct1 = newUserAccount(token);
+        UserAccount acct2 = newUserAccount(token);
+        token.mintTo{value: 4 ether}(address(0), 0);
+    }
+
+    function testFail_MintToBigMinMBQuantity() public {
+        (MadByte token,,,,) = getFixtureData();
+        UserAccount acct1 = newUserAccount(token);
+        UserAccount acct2 = newUserAccount(token);
+        token.mintTo{value: 4 ether}(address(acct1), 900*ONE_MB);
+    }
+
+    function testTransfer() public {
+        (MadByte token,,,,) = getFixtureData();
+        UserAccount acct1 = newUserAccount(token);
+        UserAccount acct2 = newUserAccount(token);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(madBytes, 399_028731704364116575);
+        token.transfer(address(acct1), 2*ONE_MB);
+
+        uint256 initialBalance1 = token.balanceOf(address(acct1));
+        uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(initialBalance1, 2*ONE_MB);
+        assertEq(initialBalance2, 0);
+
+        acct1.transfer(address(acct2), ONE_MB);
+
+        uint256 finalBalance1 = token.balanceOf(address(acct1));
+        uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(finalBalance1, initialBalance1-ONE_MB);
+        assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+        assertEq(finalBalance1, ONE_MB);
+        assertEq(finalBalance2, ONE_MB);
+    }
+
+    function testTransferFrom() public {
+        (MadByte token,,,,) = getFixtureData();
+        UserAccount acct1 = newUserAccount(token);
+        UserAccount acct2 = newUserAccount(token);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(madBytes, 399_028731704364116575);
+        token.transfer(address(acct1), 2*ONE_MB);
+
+        uint256 initialBalance1 = token.balanceOf(address(acct1));
+        uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(initialBalance1, 2*ONE_MB);
+        assertEq(initialBalance2, 0);
+
+        acct1.approve(address(this), ONE_MB);
+
+        token.transferFrom(address(acct1), address(acct2), ONE_MB);
+
+        uint256 finalBalance1 = token.balanceOf(address(acct1));
+        uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(finalBalance1, initialBalance1-ONE_MB);
+        assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+        assertEq(finalBalance1, ONE_MB);
+        assertEq(finalBalance2, ONE_MB);
+    }
+
+    function testFail_TransferFromWithoutAllowance() public {
+        (MadByte token,,,,) = getFixtureData();
+        UserAccount acct1 = newUserAccount(token);
+        UserAccount acct2 = newUserAccount(token);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(madBytes, 399_028731704364116575);
+        token.transfer(address(acct1), 2*ONE_MB);
+
+        uint256 initialBalance1 = token.balanceOf(address(acct1));
+        uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(initialBalance1, 2*ONE_MB);
+        assertEq(initialBalance2, 0);
+
+        token.transferFrom(address(acct1), address(acct2), ONE_MB);
+
+        uint256 finalBalance1 = token.balanceOf(address(acct1));
+        uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(finalBalance1, initialBalance1-ONE_MB);
+        assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+        assertEq(finalBalance1, ONE_MB);
+        assertEq(finalBalance2, ONE_MB);
+    }
+
+    function testFail_TransferMoreThanAllowance() public {
+        (MadByte token,,,,) = getFixtureData();
+        UserAccount acct1 = newUserAccount(token);
+        UserAccount acct2 = newUserAccount(token);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(madBytes, 399_028731704364116575);
+        token.transfer(address(acct1), 2*ONE_MB);
+
+        uint256 initialBalance1 = token.balanceOf(address(acct1));
+        uint256 initialBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(initialBalance1, 2*ONE_MB);
+        assertEq(initialBalance2, 0);
+
+        acct1.approve(address(this), ONE_MB/2);
+        token.transferFrom(address(acct1), address(acct2), ONE_MB);
+
+        uint256 finalBalance1 = token.balanceOf(address(acct1));
+        uint256 finalBalance2 = token.balanceOf(address(acct2));
+
+        assertEq(finalBalance1, initialBalance1-ONE_MB);
+        assertEq(finalBalance2, initialBalance2+ONE_MB);
+
+        assertEq(finalBalance1, ONE_MB);
+        assertEq(finalBalance2, ONE_MB);
+    }
+
+    function testDistribute() public {
+        (
+            MadByte token,
+            ,
+            MadStakingAccount madStaking,
+            MinerStakingAccount minerStaking,
+            FoundationAccount foundation
+        ) = getFixtureData();
+
+        // assert balances
+        assertEq(address(madStaking).balance, 0);
+        assertEq(address(minerStaking).balance, 0);
+        assertEq(address(foundation).balance, 0);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 4 ether}(0);
+        assertEq(399_028731704364116575, madBytes);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(address(token).balance, 4 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+        // assert balances
+        assertEq(stakingAmount, 1495500000000000000);
+        assertEq(minerAmount, 1495500000000000000);
+        assertEq(foundationAmount, 9000000000000000);
+
+        assertEq(address(madStaking).balance, 1495500000000000000);
+        assertEq(address(minerStaking).balance, 1495500000000000000);
+        assertEq(address(foundation).balance, 9000000000000000);
+        assertEq(address(token).balance, 1 ether);
+        assertEq(token.getPoolBalance(), 1 ether);
+    }
+
+    function testDistributeWithMoreEthereum() public {
+        (
+            MadByte token,
+            ,
+            MadStakingAccount madStaking,
+            MinerStakingAccount minerStaking,
+            FoundationAccount foundation
+        ) = getFixtureData();
+
+        // assert balances
+        assertEq(address(madStaking).balance, 0);
+        assertEq(address(minerStaking).balance, 0);
+        assertEq(address(foundation).balance, 0);
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 400 ether}(0);
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+        assertEq(madBytes, 39894_868089775762639314);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(address(token).balance, 400 ether);
+        assertEq(token.getPoolBalance(), 100 ether);
+
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+        assertEq(token.MBtoEth(token.getPoolBalance(), token.totalSupply(), token.totalSupply()), token.getPoolBalance());
+
+        // assert balances
+        assertEq(stakingAmount, 149550000000000000000);
+        assertEq(minerAmount, 149550000000000000000);
+        assertEq(foundationAmount, 900000000000000000);
+
+        assertEq(address(madStaking).balance, 149550000000000000000);
+        assertEq(address(minerStaking).balance, 149550000000000000000);
+        assertEq(address(foundation).balance, 900000000000000000);
+        assertEq(address(token).balance, 100 ether);
+        assertEq(token.getPoolBalance(), 100 ether);
+    }
+
+    function testFail_DistributeReEntrant() public {
+        (
+            MadByte token,
+            AdminAccount admin,
+            MadStakingAccount madStaking,
+            MinerStakingAccount minerStaking,
+            FoundationAccount foundation
+        ) = getFixtureData();
+
+        HackerAccountDistributeReEntry hacker = new HackerAccountDistributeReEntry();
+        hacker.setToken(token);
+        admin.setFoundation(address(hacker));
+        // assert balances
+        assertEq(address(madStaking).balance, 0);
+        assertEq(address(minerStaking).balance, 0);
+        assertEq(address(foundation).balance, 0);
+
+        // mint and transfer some tokens to the accounts
+        uint256 madBytes = token.mint{value: 400 ether}(0);
+        assertEq(madBytes, 39894_868089775762639314);
+
+        (uint256 foundationAmount, uint256 minerAmount, uint256 stakingAmount) = token.distribute();
+    }
+
+    function testBurn() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount user = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(user).balance, 0 ether);
+        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(user)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        uint256 ethReceived = user.burn(madBytes - 100*ONE_MB);
+        assertEq(ethReceived, 9_749391845405398553);
+        assertEq(address(user).balance, ethReceived);
+        assertEq(token.totalSupply(), 100*ONE_MB);
+        assertEq(token.balanceOf(address(user)), 100*ONE_MB);
+        assertEq(address(token).balance, 40 ether - ethReceived);
+        assertEq(token.getPoolBalance(), 10 ether - ethReceived);
+        ethReceived = user.burn(100*ONE_MB);
+        assertEq(ethReceived, 10 ether - 9_749391845405398553);
+        assertEq(address(user).balance, 10 ether);
+        assertEq(address(token).balance, 30 ether);
+        assertEq(token.balanceOf(address(user)), 0);
+        assertEq(token.totalSupply(), 0);
+        assertEq(token.getPoolBalance(), 0);
+        token.distribute();
+        assertEq(address(token).balance, 0);
+    }
+
+    function testBurnBillionsOfMadBytes() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount user = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(user).balance, 0 ether);
+        // Investing trillions of US dollars in ethereum
+        uint256 madBytes = token.mintTo{value: 70_000_000_000 ether}(address(this), 0);
+        assertEq(madBytes, 17501004975246203818081563855);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(address(token).balance, 70_000_000_000 ether);
+        assertEq(token.getPoolBalance(), 17500000000000000000000000000);
+        uint256 ethReceived = token.burnTo(address(user), madBytes, 0);
+    }
+
+    function testFail_BurnMoreThanPossible() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount user = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(user).balance, 0 ether);
+        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(user)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        // trying to burn more than the max supply
+        user.burn(madBytes + 100*ONE_MB);
+    }
+
+    function testFail_BurnZeroMBTokens() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount user = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(user).balance, 0 ether);
+        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(user)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        user.burn(0);
+    }
+
+    function testBurnTo() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount userTo = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(userTo).balance, 0 ether);
+        uint256 madBytes = token.mint{value: 40 ether}(0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        uint256 ethReceived = token.burnTo(address(userTo), madBytes - 100*ONE_MB, 0);
+        assertEq(ethReceived, 9_749391845405398553);
+        assertEq(address(userTo).balance, ethReceived);
+        assertEq(token.totalSupply(), 100*ONE_MB);
+        assertEq(token.balanceOf(address(this)), 100*ONE_MB);
+        assertEq(address(token).balance, 40 ether - ethReceived);
+        assertEq(token.getPoolBalance(), 10 ether - ethReceived);
+    }
+
+    function testFail_BurnToMoreThanPossible() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount userTo = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(userTo).balance, 0 ether);
+        uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        // trying to burn more than the max supply
+        token.burnTo(address(userTo), madBytes + 100*ONE_MB, 0);
+    }
+
+    function testFail_BurnToZeroMBTokens() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount userTo = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(userTo).balance, 0 ether);
+        uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        token.burnTo(address(userTo), 0, 0);
+    }
+
+    function testFail_BurnToZeroAddress() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount userTo = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(userTo).balance, 0 ether);
+        uint256 madBytes = token.mint{value: 40 ether}(0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        token.burnTo(address(0), madBytes, 0);
+    }
+
+    function testFail_BurnWithBigMinEthAmount() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount userTo = newUserAccount(token);
+        assertEq(token.totalSupply(), 0);
+        assertEq(address(token).balance, 0 ether);
+        assertEq(address(userTo).balance, 0 ether);
+        uint256 madBytes = token.mintTo{value: 40 ether}(address(this), 0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token.totalSupply(), madBytes);
+        assertEq(token.balanceOf(address(this)), madBytes);
+        assertEq(address(token).balance, 40 ether);
+        assertEq(token.getPoolBalance(), 10 ether);
+        // trying to burn more than the max supply
+        token.burnTo(address(userTo), 100*ONE_MB, 40 ether);
+    }
+
+    function testBurnReEntrant() public {
+        ( MadByte token, , , , ) = getFixtureData();
+        HackerAccountBurnReEntry hacker = new HackerAccountBurnReEntry();
+        hacker.setToken(token);
+        // assert balances
+        assertEq(token.totalSupply(), 0);
+
+        // mint some tokens to the accounts
+        uint256 madBytesHacker = token.mintTo{value: 40 ether}(address(hacker), 0);
+        assertEq(madBytesHacker, 3990_217121585928137263);
+        assertEq(token.balanceOf(address(hacker)), madBytesHacker);
+        // Transferring the excess to get only 100 MD on the hacker account to make checks easier
+        hacker.transfer(address(this), madBytesHacker - 100*ONE_MB);
+        assertEq(token.balanceOf(address(hacker)), 100*ONE_MB);
+        emit log_named_uint("MadNet balance hacker:", token.balanceOf(address(hacker)));
+
+        assertEq(address(token).balance, 40 ether);
+        assertEq(address(hacker).balance, 0 ether);
+
+        // burning with reentrancy 5 times
+        uint256 ethReceivedHacker = hacker.burn(20*ONE_MB);
+
+        assertEq(token.balanceOf(address(hacker)), 0*ONE_MB);
+        assertEq(address(hacker).balance, 250617721342188290);
+        emit log_named_uint("Real Hacker Balance ETH", address(hacker).balance);
+
+        // If this check fails we had a reentrancy issue
+        assertEq(address(token).balance, 39_749382278657811710);
+
+        // testing a honest user
+        ( MadByte token2, , , , ) = getFixtureData();
+        assertEq(token2.totalSupply(), 0);
+        UserAccount honestUser = newUserAccount(token2);
+        uint256 madBytes = token2.mintTo{value: 40 ether}(address(honestUser), 0);
+        assertEq(madBytes, 3990_217121585928137263);
+        assertEq(token2.balanceOf(address(honestUser)), madBytes);
+        // Transferring the excess to get only 100 MD on the hacker account to make checks easier
+        honestUser.transfer(address(this), madBytes - 100*ONE_MB);
+        assertEq(address(token2).balance, 40 ether);
+        assertEq(address(honestUser).balance, 0 ether);
+        emit log_named_uint("Initial MadNet balance honestUser:", token2.balanceOf(address(honestUser)));
+
+        uint256 totalBurnt = 0;
+        for (uint256 i=0; i<5; i++){
+            totalBurnt += honestUser.burn(20*ONE_MB);
+        }
+        // the honest user must have the same balance as the hacker
+        assertEq(token2.balanceOf(address(honestUser)), 0);
+        assertEq(address(honestUser).balance, address(hacker).balance);
+        assertEq(address(token2).balance, address(token).balance);
+        emit log_named_uint("Honest Balance ETH", address(honestUser).balance);
+    }
+
+    function testMarketSpreadWithMintAndBurn() public {
+        ( MadByte token, , , , ) = getFixtureData();
+
+        UserAccount user = newUserAccount(token);
+        uint256 supply = token.totalSupply();
+        assertEq(supply, 0);
+
+        // mint
+        uint256 mintedTokens = user.mint{value: 40 ether}(0);
+        assertEq(mintedTokens, token.balanceOf(address(user)));
+
+        // burn
+        uint256 receivedEther = user.burn(mintedTokens);
+        assertEq(receivedEther, 10 ether);
+    }
+
+    function test_MintAndBurnALotThanBurnEverything(uint96 amountETH) public {
+        if (amountETH == 0) {
+            return;
+        }
+        uint256 maxIt = 10;
+        if (amountETH <= maxIt) {
+            amountETH = amountETH+uint96(maxIt)**2+1;
+        }
+        TokenPure token = new TokenPure();
+        uint256 initialMB = token.mint(amountETH);
+        emit log_named_uint("Initial supply:    ", token.totalSupply());
+        uint256 madBytes = token.mint(amountETH);
+        emit log_named_uint("Mb generated 2:   ", madBytes);
+        emit log_named_uint("Initial supply2:   ", token.totalSupply());
+
+        uint256 cumulativeMBBurned = 0;
+        uint256 cumulativeMBMinted = 0;
+        uint256 cumulativeETHBurned = 0;
+        uint256 cumulativeETHMinted = 0;
+        uint256 amountBurned = madBytes/maxIt;
+        uint256 amountMinted = amountETH/10000;
+        if (amountMinted == 0) {
+            amountMinted=1;
+        }
+        for (uint256 i=0; i<maxIt; i++) {
+            amountBurned = _min(amountBurned, token.totalSupply());
+            cumulativeETHBurned += token.burn(amountBurned);
+            cumulativeMBBurned += amountBurned;
+            cumulativeMBMinted += token.mint(amountMinted);
+            cumulativeETHMinted += amountMinted;
+        }
+        int256 burnedMBDiff = int256(cumulativeMBBurned)-int256(cumulativeMBMinted);
+        if (burnedMBDiff < 0) {
+            burnedMBDiff *= -1;
+        }
+        uint256 burnedETH = token.burn(token.totalSupply());
+
+        emit log("=======================================================");
+        emit log_named_uint("Token Balance:    ", token.totalSupply());
+        emit log_named_uint("amountMinted ETH   ", amountMinted);
+        emit log_named_uint("amountBurned       ", amountBurned);
+        emit log_named_uint("cumulativeMBBurned ", cumulativeMBBurned);
+        emit log_named_uint("cumulativeMBMinted ", cumulativeMBMinted);
+        emit log_named_uint("cumulativeETHBurned", cumulativeETHBurned);
+        emit log_named_uint("cumulativeETHMinted", cumulativeETHMinted);
+        emit log_named_int("Diff MB after loop ", burnedMBDiff);
+        emit log_named_uint("Final ETH burned   ", burnedETH);
+        emit log_named_uint("Token1 Balance:    ", token.poolBalance());
+        emit log_named_uint("Token1 supply:     ", token.totalSupply());
+        assertTrue(token.poolBalance() >= 0);
+        assertEq(token.totalSupply(), 0);
+    }
+
+    function test_ConversionMBToEthAndEthMBFunctions(uint96 amountEth) public {
+        ( MadByte token, , , , ) = getFixtureData();
+
+        if (amountEth == 0) {
+            return;
+        }
+        uint256 poolBalance = amountEth;
+        uint256 totalSupply = token.EthtoMB(0, amountEth);
+        uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
+        uint256 totalSupplyAfter = _fx(poolBalanceAfter);
+        uint256 mb = totalSupply - totalSupplyAfter;
+        uint256 returnedEth = token.MBtoEth(poolBalance, totalSupply, mb);
+        emit log_named_uint("Diff:", poolBalance - returnedEth);
+        assertTrue(poolBalance - returnedEth == poolBalanceAfter);
+    }
+
+    function test_ConversionMBToEthAndEthMBToken(uint96 amountEth) public {
+        TokenPure token = new TokenPure();
+        if (amountEth == 0) {
+            return;
+        }
+        uint256 totalSupply = token.mint(amountEth);
+        uint256 poolBalanceAfter = uint256(keccak256(abi.encodePacked(amountEth))) % amountEth;
+        uint256 totalSupplyAfter = _fx(poolBalanceAfter);
+        uint256 mb = totalSupply - totalSupplyAfter;
+        uint256 poolBalanceBeforeBurn = token.poolBalance();
+        uint256 returnedEth = token.burn(mb);
+        emit log_named_uint("Tt supply after", totalSupplyAfter);
+        emit log_named_uint("MB burned      ", mb);
+        emit log_named_uint("Pool balance   ", poolBalanceBeforeBurn);
+        emit log_named_uint("Pool After     ", poolBalanceAfter);
+        emit log_named_uint("returnedEth    ", returnedEth);
+        emit log_named_uint("Diff           ", poolBalanceBeforeBurn - returnedEth);
+        emit log_named_uint("ExpectedDiff   ", poolBalanceAfter);
+        emit log_named_int("Delta          ", int256(poolBalanceAfter) - int256(poolBalanceBeforeBurn - returnedEth));
+        assertTrue(poolBalanceBeforeBurn - returnedEth == poolBalanceAfter);
+    }
+
+    function testInvariantHold() public {
+        /*
+        tests if the invariant holds with mint and burn:
+        ethIn / burn(mint(ethIn)) >= marketSpread;
+        */
+
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount user = newUserAccount(token);
+        UserAccount user2 = newUserAccount(token);
+
+        uint256 madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+        uint256 ethReceived = user.burn(madBytes);
+
+        assertTrue(40 ether / ethReceived >= 4);
+
+        madBytes = token.mintTo{value: 40 ether}(address(user2), 0);
+        ethReceived = user2.burn(madBytes);
+
+        assertTrue(40 ether / ethReceived >= 4);
+
+        madBytes = token.mintTo{value: 40 ether}(address(user), 0);
+        uint256 madBytes2 = token.mintTo{value: 40 ether}(address(user2), 0);
+        uint256 ethReceived2 = user2.burn(madBytes2);
+        ethReceived = user.burn(madBytes);
+
+        emit log_named_uint("inv1.1:", 40 ether / ethReceived);
+        emit log_named_uint("inv1.2:", 40 ether / ethReceived2);
+
+        assertTrue(40 ether / ethReceived >= 4);
+        assertTrue(40 ether / ethReceived2 >= 4);
+
+        // amounts that are not multiple of 4
+        madBytes = token.mintTo{value: 53 ether}(address(user), 0);
+        madBytes2 = token.mintTo{value: 53 ether}(address(user2), 0);
+        ethReceived2 = user2.burn(madBytes2);
+        ethReceived = user.burn(madBytes);
+
+        emit log_named_uint("inv1.1:", 53 ether / ethReceived);
+        emit log_named_uint("inv1.2:", 53 ether / ethReceived2);
+
+        assertTrue(53 ether / ethReceived >= 4);
+        assertTrue(53 ether / ethReceived2 >= 4);
+    }
+
+    function testInvariantHold2() public {
+        /*
+        tests if the invariant holds with mint and burn:
+        ethIn / burn(mint(ethIn)) >= marketSpread;
+        */
+
+        ( MadByte token, , , , ) = getFixtureData();
+        UserAccount user = newUserAccount(token);
+        UserAccount user2 = newUserAccount(token);
+
+        uint256 madBytes = token.mintTo{value: 4*2000 ether}(address(user), 0);
+        uint256 ethReceived = user.burn(madBytes);
+
+        emit log_named_uint("inv3:", 2000 ether / ethReceived);
+        assertTrue(4*2000 ether / ethReceived >= 4);
+
+    }
 
     function testFail_QueryNonexistingDepositId() public {
         ( MadByte token, , , , ) = getFixtureData();

--- a/src/StakeNFT.sol
+++ b/src/StakeNFT.sol
@@ -84,12 +84,12 @@ contract StakeNFT is ERC721, MagicValue, Admin, Governance, CircuitBreaker, Atom
         _MadToken = MadToken_;
     }
 
-    /// @dev tripCB opens the circuit breaker may only be called by an _admin
+    /// @dev tripCB opens the circuit breaker may only be called by _admin
     function tripCB() public override onlyAdmin {
         _tripCB();
     }
 
-    /// @dev sets the governance contract, must only be called by and _admin
+    /// @dev sets the governance contract, must only be called by _admin
     function setGovernance(address governance_) public override onlyAdmin {
         _setGovernance(governance_);
     }


### PR DESCRIPTION
## Scope

Add methods to handle the Madbyte deposit into the Madnet chain inside the MadBytes contract. This PR also reorganize the code in the MadBytes contract (all public methods are defined first and the internal methods are defined later). This PR closes https://madhive.atlassian.net/browse/MP-56
