### PR TITLE
Updated StakeNFT to not lock withdraws when mintingTo

### DIFF
--- a/src/tokens/StakeNFT.sol
+++ b/src/tokens/StakeNFT.sol
@@ -235,7 +235,6 @@ contract StakeNFT is ERC721, MagicValue, Admin, Governance, CircuitBreaker, Atom
         tokenID = _mintNFT(to_, amount_);
         if (lockDuration_ > 0) {
             _lockPosition(tokenID, lockDuration_);
-            _lockWithdraw(tokenID, lockDuration_);
         }
         return tokenID;
     }

--- a/tests/tokens/StakeNFT.t.sol
+++ b/tests/tokens/StakeNFT.t.sol
@@ -2613,6 +2613,8 @@ contract StakeNFTTest is DSTest {
     function testCollectRewardsAfterMinting() public {
         (StakeNFT stakeNFT, MadTokenMock madToken, , ) = getFixtureData();
         UserAccount user = newUserAccount(madToken, stakeNFT);
+        UserAccount user2 = newUserAccount(madToken, stakeNFT);
+        payable(address(user2)).transfer(10 ether);
 
         madToken.transfer(address(user), 100 * ONE_MADTOKEN);
 
@@ -2627,30 +2629,40 @@ contract StakeNFTTest is DSTest {
 
         setBlockNumber(block.number+2);
 
+        user2.depositEth(10 ether);
+
         user.collectEth(tokenID);
 
         assertEq(madToken.balanceOf(address(user)), 0);
+        assertEq(address(user).balance, 10 ether);
+        assertEq(address(user2).balance, 0);
         assertEq(madToken.balanceOf(address(stakeNFT)), 100 * ONE_MADTOKEN);
     }
 
     function testCollectRewardsAfterMintingTo() public {
         (StakeNFT stakeNFT, MadTokenMock madToken, , ) = getFixtureData();
         UserAccount user = newUserAccount(madToken, stakeNFT);
+        UserAccount user2 = newUserAccount(madToken, stakeNFT);
+        payable(address(user2)).transfer(10 ether);
 
         madToken.approve(address(stakeNFT), 100 * ONE_MADTOKEN);
 
-        uint256 tokenID = stakeNFT.mintTo(address(user), 100 * ONE_MADTOKEN, 0);
+        uint256 tokenID = stakeNFT.mintTo(address(user), 100 * ONE_MADTOKEN, 10);
 
         assertPosition(
             getCurrentPosition(stakeNFT, tokenID),
-            StakeNFT.Position(uint224(100 * ONE_MADTOKEN), 1, 1, 0, 0)
+            StakeNFT.Position(uint224(100 * ONE_MADTOKEN), 10, 1, 0, 0)
         );
 
         setBlockNumber(block.number+2);
 
+        user2.depositEth(10 ether);
+
         user.collectEth(tokenID);
 
         assertEq(madToken.balanceOf(address(user)), 0);
+        assertEq(address(user).balance, 10 ether);
+        assertEq(address(user2).balance, 0);
         assertEq(madToken.balanceOf(address(stakeNFT)), 100 * ONE_MADTOKEN);
     }
 

--- a/tests/tokens/StakeNFT.t.sol
+++ b/tests/tokens/StakeNFT.t.sol
@@ -624,7 +624,7 @@ contract StakeNFTTest is DSTest {
 
         assertPosition(
             getCurrentPosition(stakeNFT, tokenID),
-            StakeNFT.Position(1000, 10, 10, 0, 0)
+            StakeNFT.Position(1000, 10, 1, 0, 0)
         );
         assertEq(stakeNFT.balanceOf(address(user)), 1);
         assertEq(stakeNFT.ownerOf(tokenID), address(user));
@@ -819,7 +819,7 @@ contract StakeNFTTest is DSTest {
         uint256 tokenID = user.mintTo(address(user2), 1000, 10);
         assertPosition(
             getCurrentPosition(stakeNFT, tokenID),
-            StakeNFT.Position(1000, 10, 10, 0, 0)
+            StakeNFT.Position(1000, 10, 1, 0, 0)
         );
 
         assertEq(madToken.balanceOf(address(user)), 0);
@@ -2603,6 +2603,50 @@ contract StakeNFTTest is DSTest {
         user.lockWithdraw(tokenID, 10);
 
         setBlockNumber(block.number+11);
+
+        user.collectEth(tokenID);
+
+        assertEq(madToken.balanceOf(address(user)), 0);
+        assertEq(madToken.balanceOf(address(stakeNFT)), 100 * ONE_MADTOKEN);
+    }
+
+    function testCollectRewardsAfterMinting() public {
+        (StakeNFT stakeNFT, MadTokenMock madToken, , ) = getFixtureData();
+        UserAccount user = newUserAccount(madToken, stakeNFT);
+
+        madToken.transfer(address(user), 100 * ONE_MADTOKEN);
+
+        user.approve(address(stakeNFT), 100 * ONE_MADTOKEN);
+
+        uint256 tokenID = user.mint(100 * ONE_MADTOKEN);
+
+        assertPosition(
+            getCurrentPosition(stakeNFT, tokenID),
+            StakeNFT.Position(uint224(100 * ONE_MADTOKEN), 1, 1, 0, 0)
+        );
+
+        setBlockNumber(block.number+2);
+
+        user.collectEth(tokenID);
+
+        assertEq(madToken.balanceOf(address(user)), 0);
+        assertEq(madToken.balanceOf(address(stakeNFT)), 100 * ONE_MADTOKEN);
+    }
+
+    function testCollectRewardsAfterMintingTo() public {
+        (StakeNFT stakeNFT, MadTokenMock madToken, , ) = getFixtureData();
+        UserAccount user = newUserAccount(madToken, stakeNFT);
+
+        madToken.approve(address(stakeNFT), 100 * ONE_MADTOKEN);
+
+        uint256 tokenID = stakeNFT.mintTo(address(user), 100 * ONE_MADTOKEN, 0);
+
+        assertPosition(
+            getCurrentPosition(stakeNFT, tokenID),
+            StakeNFT.Position(uint224(100 * ONE_MADTOKEN), 1, 1, 0, 0)
+        );
+
+        setBlockNumber(block.number+2);
 
         user.collectEth(tokenID);
 


### PR DESCRIPTION
## Scope

#### What is changing with this PR?
Users will now be able to collect/withdraw rewards after mintTo. Previously users would have their withdrawal capabilities locked by default for a specified `duration`, but that no longer applies. `duration` only applies to lock the position against `burn`.

## Why?

This is important so that targets of `mintTo` can collect rewards right away without the need to wait `duration`.

