### PR TITLE
Fix multicall tests

### DIFF
--- a/src/factory/MadnetFactoryBase.sol
+++ b/src/factory/MadnetFactoryBase.sol
@@ -333,7 +333,7 @@ abstract contract MadnetFactoryBase is DeterministicAddress, ProxyUpgrader {
         bytes calldata _initCallData
     ) internal {
         address proxy = DeterministicAddress.getMetamorphicContractAddress(_salt, address(this));
-        __upgrade(proxy, _newImpl);
+        __upgrade(proxy, _newImpl); 
         assert(IProxy(proxy).getImplementationAddress() == _newImpl);
         initializeContractInternal(proxy, _initCallData);
     }

--- a/tests/factory/APIGetters.test.ts
+++ b/tests/factory/APIGetters.test.ts
@@ -1,4 +1,4 @@
-import { ethers } from "hardhat";
+import { ethers, artifacts } from "hardhat";
 import {
   deployStatic,
   deployUpgradeable,
@@ -14,7 +14,6 @@ import {
   getMetamorphicAddress,
   MADNET_FACTORY,
   PROXY,
-  utilsBase,
 } from "./Setup.test";
 
 describe("Madnetfactory API test", async () => {
@@ -25,11 +24,13 @@ describe("Madnetfactory API test", async () => {
   let factory: MadnetFactory;
 
   beforeEach(async () => {
+    let utilsBase = await ethers.getContractFactory("Utils");
     accounts = await getAccounts();
     //set owner and delegator
     firstOwner = accounts[0];
     firstDelegator = accounts[1];
-    utilsContract = await utilsBase.new();
+
+    utilsContract = await utilsBase.deploy();
     factory = await deployFactory(MADNET_FACTORY);
     let cSize = await utilsContract.getCodeSize(factory.address);
     expect(cSize.toNumber()).to.be.greaterThan(0);

--- a/tests/factory/CLI.test.ts
+++ b/tests/factory/CLI.test.ts
@@ -4,13 +4,13 @@ import {
   getAccounts,
   MADNET_FACTORY,
   predictFactoryAddress,
-  utilsBase,
 } from "./Setup.test";
 import { artifacts, ethers, run } from "hardhat";
 import { getDefaultFactoryAddress } from "../../scripts/lib/factoryStateUtils";
 import { MadnetFactory } from "../../typechain-types";
 
 describe("Cli tasks", async () => {
+  let utilsBase;
   let firstOwner: string;
   let firstDelegator: string;
   let accounts: Array<string> = [];

--- a/tests/factory/MadnetFactory.test.ts
+++ b/tests/factory/MadnetFactory.test.ts
@@ -25,13 +25,12 @@ import {
   MOCK_INITIALIZABLE,
   proxyBase,
   RECEIPT,
-  utilsBase,
 } from "./Setup.test";
-import { ethers } from "hardhat";
+import { ethers, artifacts } from "hardhat";
 import { BytesLike, ContractFactory } from "ethers";
 import { MadnetFactory, Utils } from "../../typechain-types";
-
 describe("Madnet Contract Factory", () => {
+  let utilsBase
   let firstOwner: string;
   let secondOwner: string;
   let firstDelegator: string;
@@ -44,7 +43,8 @@ describe("Madnet Contract Factory", () => {
     firstOwner = accounts[0];
     secondOwner = accounts[1];
     firstDelegator = accounts[2];
-    utilsContract = await utilsBase.new();
+    let UtilsBase = await ethers.getContractFactory("Utils")
+    utilsContract = await UtilsBase.deploy();
     factory = await deployFactory(MADNET_FACTORY);
     let cSize = await utilsContract.getCodeSize(factory.address);
     expect(cSize.toNumber()).to.be.greaterThan(0);
@@ -421,6 +421,6 @@ describe("Madnet Contract Factory", () => {
     let lockResponse = await proxyContract.upgradeLock();
     let receipt = await lockResponse.wait();
     expect(receipt.status).to.equal(1);
-    expect(factory.upgradeProxy(salt, endPoint.address, "0x"));
+    await expect(factory.upgradeProxy(salt, endPoint.address, "0x")).to.revertedWith("reverted with an unrecognized custom error");
   });
 });

--- a/tests/factory/MultiCall.test.ts
+++ b/tests/factory/MultiCall.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import { ContractFactory } from "ethers";
-import { ethers } from "hardhat";
-import { MadnetFactory, Utils } from "../../typechain-types";
+import { ethers, artifacts } from "hardhat";
+import { MadnetFactory, Utils, Utils__factory } from "../../typechain-types";
 import {
   CONTRACT_ADDR,
   DEPLOYED_PROXY,
@@ -20,10 +19,12 @@ import {
   mockBase,
   proxyBase,
   proxyMockLogicTest,
-  utilsBase,
 } from "./Setup.test";
 
-describe("Multicall deploy meta", async () => {
+
+
+describe("Multicall deploy proxy", () => {
+  let utilsBase
   let firstOwner: string;
   let secondOwner: string;
   let firstDelegator: string;
@@ -36,157 +37,161 @@ describe("Multicall deploy meta", async () => {
     firstOwner = accounts[0];
     secondOwner = accounts[1];
     firstDelegator = accounts[2];
-    utilsContract = await utilsBase.new();
+    let UtilsBase = await ethers.getContractFactory("Utils")
+    utilsContract = await UtilsBase.deploy();
     factory = await deployFactory(MADNET_FACTORY);
     let cSize = await utilsContract.getCodeSize(factory.address);
     expect(cSize.toNumber()).to.be.greaterThan(0);
   });
 
-  describe("Multicall deploy proxy", async () => {
+  it("multicall deployproxy, deploycreate, upgradeproxy expect success", async () => {
+    
+    let Salt = getSalt();
+    let mockCon = await ethers.getContractFactory("Mock");
+    let endPoint = await endPointBase.new(factory.address);
+    //deploy code for mock with constructor args i = 2
+    let deployTX = mockCon.getDeployTransaction(2, "s");
+    const MadnetFactory = await ethers.getContractFactory("MadnetFactory");
+    let transactionCount = await ethers.provider.getTransactionCount(
+      factory.address
+    );
+    //calculate the deployCreate Address
+    let expectedMockLogicAddr = getCreateAddress(
+      factory.address,
+      transactionCount + 1
+    );
+    //encoded function call to deployProxy
+    let deployProxy = MadnetFactory.interface.encodeFunctionData(
+      "deployProxy",
+      [Salt]
+    );
+    //encoded function call to deployCreate
+    let deployCreate = MadnetFactory.interface.encodeFunctionData(
+      "deployCreate",
+      [deployTX.data]
+    );
+    //encoded function call to upgradeProxy
+    let upgradeProxy = MadnetFactory.interface.encodeFunctionData(
+      "upgradeProxy",
+      [Salt, expectedMockLogicAddr, "0x"]
+    );
+    let receipt = await factory.multiCall([
+      deployProxy,
+      deployCreate,
+      upgradeProxy,
+    ]);
+    let mockLogicAddr = await getEventVar(
+      receipt,
+      DEPLOYED_RAW,
+      CONTRACT_ADDR
+    );
+    let proxyAddr = await getEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR);
+    expect(mockLogicAddr).to.equal(expectedMockLogicAddr);
+    // console.log("MULTICALL DEPLOYPROXY, DEPLOYCREATE, UPGRADEPROXY GASUSED: ", receipt["receipt"]["gasUsed"]);
+    //check the proxy behavior
+    await proxyMockLogicTest(
+      mockBase,
+      Salt,
+      proxyAddr,
+      mockLogicAddr,
+      endPoint.address,
+      factory.address
+    );
+  });
 
-    it("multicall deployproxy, deploycreate, upgradeproxy expect success", async () => {
-      let Salt = getSalt();
-      let mockCon = await ethers.getContractFactory("Mock");
-      let endPoint = await endPointBase.new(factory.address);
-      //deploy code for mock with constructor args i = 2
-      let deployTX = mockCon.getDeployTransaction(2, "s");
-      const MadnetFactory = await ethers.getContractFactory("MadnetFactory");
-      let transactionCount = await ethers.provider.getTransactionCount(
-        factory.address
-      );
-      //calculate the deployCreate Address
-      let expectedMockLogicAddr = getCreateAddress(
-        factory.address,
-        transactionCount + 1
-      );
-      //encoded function call to deployProxy
-      let deployProxy = MadnetFactory.interface.encodeFunctionData(
-        "deployProxy",
-        [Salt]
-      );
-      //encoded function call to deployCreate
-      let deployCreate = MadnetFactory.interface.encodeFunctionData(
-        "deployCreate",
-        [deployTX.data]
-      );
-      //encoded function call to upgradeProxy
-      let upgradeProxy = MadnetFactory.interface.encodeFunctionData(
-        "upgradeProxy",
-        [Salt, expectedMockLogicAddr, "0x"]
-      );
-      let receipt = await factory.multiCall([
-        deployProxy,
-        deployCreate,
-        upgradeProxy,
-      ]);
-      let mockLogicAddr = await getEventVar(
-        receipt,
-        DEPLOYED_RAW,
-        CONTRACT_ADDR
-      );
-      let proxyAddr = await getEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR);
-      expect(mockLogicAddr).to.equal(expectedMockLogicAddr);
-      // console.log("MULTICALL DEPLOYPROXY, DEPLOYCREATE, UPGRADEPROXY GASUSED: ", receipt["receipt"]["gasUsed"]);
-      //check the proxy behavior
-      await proxyMockLogicTest(
-        mockBase,
-        Salt,
-        proxyAddr,
-        mockLogicAddr,
-        endPoint.address,
-        factory.address
-      );
-    });
+  it("multicall deployproxy, deploytemplate, deploystatic, upgradeproxy, expect success", async () => {
+    let UtilsBase: Utils__factory = await ethers.getContractFactory("Utils")
+    let utilsContract = await UtilsBase.deploy();
+    let endPoint = await endPointBase.new(factory.address);
+    let proxySalt = getSalt();
+    let mockCon = await ethers.getContractFactory("Mock");
+    //salt for deployStatic
+    let metaSalt = getSalt();
+    //deploy code for mock with constructor args i = 2, _p = "s"
+    let deployTX = mockCon.getDeployTransaction(2, "s");
+    let expectedMetaAddr = getMetamorphicAddress(factory.address, metaSalt);
+    const MadnetFactory = await ethers.getContractFactory("MadnetFactory");
+    //encoded function call to deployProxy
+    let deployProxy = MadnetFactory.interface.encodeFunctionData(
+      "deployProxy",
+      [proxySalt]
+    );
+    //encoded function call to deployTemplate
+    let deployTemplate = MadnetFactory.interface.encodeFunctionData(
+      "deployTemplate",
+      [deployTX.data]
+    );
+    //encoded function call to deployStatic
+    let deployStatic = MadnetFactory.interface.encodeFunctionData(
+      "deployStatic",
+      [metaSalt, "0x"]
+    );
+    expect(proxySalt != metaSalt).to.equal(true);
+    //encoded function call to upgradeProxy
+    let upgradeProxy = MadnetFactory.interface.encodeFunctionData(
+      "upgradeProxy",
+      [proxySalt, expectedMetaAddr, "0x"]
+    );
+    let receipt = await factory.multiCall([
+      deployProxy,
+      deployTemplate,
+      deployStatic,
+      upgradeProxy,
+    ]);
+    //get the deployed template contract address from the event
+    //get the deployed metamorphic contract address from the event
+    let metaAddr = await getEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR);
+    let proxyAddr = await getEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR);
+    let proxyCsize = await utilsContract.getCodeSize(proxyAddr);
+    expect(proxyCsize.toNumber()).to.equal(
+      (proxyBase.deployedBytecode.length - 2) / 2
+    );
+    await proxyMockLogicTest(
+      mockBase,
+      proxySalt,
+      proxyAddr,
+      metaAddr,
+      endPoint.address,
+      factory.address
+    );
+    // console.log("MULTICALL DEPLOYPROXY, DEPLOYTEMPLATE, DEPLOYSTATIC, UPGRADEPROXY GASUSED: ", receipt["receipt"]["gasUsed"]);
+  });
 
-    it("multicall deployproxy, deploytemplate, deploystatic, upgradeproxy, expect success", async () => {
-      let endPoint = await endPointBase.new(factory.address);
-      let proxySalt = getSalt();
-      let mockCon: ContractFactory = await ethers.getContractFactory("Mock");
-      //salt for deployStatic
-      let metaSalt = getSalt();
-      //deploy code for mock with constructor args i = 2, _p = "s"
-      let deployTX = mockCon.getDeployTransaction(2, "s");
-      let expectedMetaAddr = getMetamorphicAddress(factory.address, metaSalt);
-      const MadnetFactory = await ethers.getContractFactory("MadnetFactory");
-      //encoded function call to deployProxy
-      let deployProxy = MadnetFactory.interface.encodeFunctionData(
-        "deployProxy",
-        [proxySalt]
-      );
-      //encoded function call to deployTemplate
-      let deployTemplate = MadnetFactory.interface.encodeFunctionData(
-        "deployTemplate",
-        [deployTX.data]
-      );
-      //encoded function call to deployStatic
-      let deployStatic = MadnetFactory.interface.encodeFunctionData(
-        "deployStatic",
-        [metaSalt, "0x"]
-      );
-      expect(proxySalt != metaSalt).to.equal(true);
-      //encoded function call to upgradeProxy
-      let upgradeProxy = MadnetFactory.interface.encodeFunctionData(
-        "upgradeProxy",
-        [proxySalt, expectedMetaAddr, "0x"]
-      );
-      let receipt = await factory.multiCall([
-        deployProxy,
-        deployTemplate,
-        deployStatic,
-        upgradeProxy,
-      ]);
-      //get the deployed template contract address from the event
-      //get the deployed metamorphic contract address from the event
-      let metaAddr = await getEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR);
-      let proxyAddr = await getEventVar(receipt, DEPLOYED_PROXY, CONTRACT_ADDR);
-      let proxyCsize = await utilsContract.getCodeSize(proxyAddr);
-      expect(proxyCsize.toNumber()).to.equal(
-        (proxyBase.deployedBytecode.length - 2) / 2
-      );
-      await proxyMockLogicTest(
-        mockBase,
-        proxySalt,
-        proxyAddr,
-        metaAddr,
-        endPoint.address,
-        factory.address
-      );
-      // console.log("MULTICALL DEPLOYPROXY, DEPLOYTEMPLATE, DEPLOYSTATIC, UPGRADEPROXY GASUSED: ", receipt["receipt"]["gasUsed"]);
-    });
-
-    it("multicall deploytemplate, deploystatic", async () => {
-      let Salt = getSalt();
-      //ethers instance of Mock contract abstraction
-      let mockCon = await ethers.getContractFactory("Mock");
-      //deploy code for mock with constructor args i = 2
-      let deployTX = mockCon.getDeployTransaction(2, "s");
-      const MadnetFactory = await ethers.getContractFactory("MadnetFactory");
-      //encoded function call to deployTemplate
-      let deployTemplate = MadnetFactory.interface.encodeFunctionData(
-        "deployTemplate",
-        [deployTX.data]
-      );
-      //encoded function call to deployStatic
-      let deployStatic = MadnetFactory.interface.encodeFunctionData(
-        "deployStatic",
-        [Salt, "0x"]
-      );
-      let receipt = await factory.multiCall([deployTemplate, deployStatic]);
-      //get the deployed template contract address from the event
-      let tempSDAddr = await getEventVar(
-        receipt,
-        DEPLOYED_TEMPLATE,
-        CONTRACT_ADDR
-      );
-      //get the deployed metamorphic contract address from the event
-      let metaAddr = await getEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR);
-      let tempCSize = await utilsContract.getCodeSize(tempSDAddr);
-      let staticCSize = await utilsContract.getCodeSize(metaAddr);
-      expect(tempCSize.toNumber()).to.be.greaterThan(0);
-      expect(staticCSize.toNumber()).to.be.greaterThan(0);
-      //test logic at deployed metamorphic location
-      await metaMockLogicTest(mockBase, metaAddr, factory.address);
-      // console.log("MULTICALL DEPLOYTEMPLATE, DEPLOYSTATIC GASUSED: ", receipt["receipt"]["gasUsed"]);
-    });
+  it("multicall deploytemplate, deploystatic", async () => {
+    let UtilsBase: Utils__factory = await ethers.getContractFactory("Utils")
+    let utilsContract = await UtilsBase.deploy();
+    let Salt = getSalt();
+    //ethers instance of Mock contract abstraction
+    let mockCon = await ethers.getContractFactory("Mock");
+    //deploy code for mock with constructor args i = 2
+    let deployTX = mockCon.getDeployTransaction(2, "s");
+    const MadnetFactory = await ethers.getContractFactory("MadnetFactory");
+    //encoded function call to deployTemplate
+    let deployTemplate = MadnetFactory.interface.encodeFunctionData(
+      "deployTemplate",
+      [deployTX.data]
+    );
+    //encoded function call to deployStatic
+    let deployStatic = MadnetFactory.interface.encodeFunctionData(
+      "deployStatic",
+      [Salt, "0x"]
+    );
+    let receipt = await factory.multiCall([deployTemplate, deployStatic]);
+    //get the deployed template contract address from the event
+    let tempSDAddr = await getEventVar(
+      receipt,
+      DEPLOYED_TEMPLATE,
+      CONTRACT_ADDR
+    );
+    //get the deployed metamorphic contract address from the event
+    let metaAddr = await getEventVar(receipt, DEPLOYED_STATIC, CONTRACT_ADDR);
+    let tempCSize = await utilsContract.getCodeSize(tempSDAddr);
+    let staticCSize = await utilsContract.getCodeSize(metaAddr);
+    expect(tempCSize.toNumber()).to.be.greaterThan(0);
+    expect(staticCSize.toNumber()).to.be.greaterThan(0);
+    //test logic at deployed metamorphic location
+    await metaMockLogicTest(mockBase, metaAddr, factory.address);
+    // console.log("MULTICALL DEPLOYTEMPLATE, DEPLOYSTATIC GASUSED: ", receipt["receipt"]["gasUsed"]);
   });
 });
+

--- a/tests/factory/Setup.test.ts
+++ b/tests/factory/Setup.test.ts
@@ -21,7 +21,7 @@ export const endPointBase = artifacts.require(END_POINT);
 export const mockBase = artifacts.require(MOCK);
 export const mockInitBase = artifacts.require(MOCK_INITIALIZABLE);
 export const mockFactoryBase = artifacts.require("MockFactory");
-export const utilsBase = artifacts.require("Utils");
+
 
 export async function getAccounts() {
   let signers = await ethers.getSigners();

--- a/tests/factory/proxy/Proxy.test.ts
+++ b/tests/factory/proxy/Proxy.test.ts
@@ -1,13 +1,12 @@
 import { TransactionRequest } from '@ethersproject/abstract-provider';
 import { BN, expectEvent} from '@openzeppelin/test-helpers';
-import { ethers } from 'hardhat';
+import { ethers, artifacts } from 'hardhat';
 import { EndPoint, EndPointLockable, MadnetFactory, Proxy } from '../../../typechain-types';
 import { expect } from '../../chai-setup';
 import { CONTRACT_ADDR, DEPLOYED_PROXY, deployFactory, expectTxSuccess, getAccounts, getEventVar, getMetamorphicAddress, getSalt, MADNET_FACTORY } from '../Setup.test';
 
 
 describe("PROXY", async () => {
-
     it("deploy proxy through factory", async () => {
         let factory = await deployFactory(MADNET_FACTORY);
         let salt = getSalt();


### PR DESCRIPTION
## Scope

What is changing with this PR?

## Why?

Why are we doing this?

## Todos
clean up Utils contract import in tests. move to setup and use ethers.getContractFactory()
- [ ] ???
